### PR TITLE
Construct peripherals in main

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,11 @@ use embassy_rp::{
     bind_interrupts,
     block::ImageDef,
     config::Config,
-    gpio::{Level, Output, Pull},
+    gpio::{Input, Level, Output, Pull},
     i2c::{Config as I2cConfig, I2c, InterruptHandler as I2cInterruptHandler},
     peripherals::{I2C0, PIO0},
     pio::InterruptHandler as PioInterruptHandler,
-    pwm::Pwm,
+    pwm::{InputMode, Pwm},
 };
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
 use panic_probe as _;
@@ -25,10 +25,19 @@ use static_cell::StaticCell;
 use crate::{
     system::event::ButtonId,
     task::{
-        autonomous_drive::autonomous_drive, battery_charge_read::battery_charge_read, display::display, drive::drive,
-        encoder_read::encoder_read, imu_read::inertial_measurement_read, ir_obstacle_detect::ir_obstacle_detect,
-        monitor_motion::motion_correction_control, orchestrate::orchestrate, rc_control::rc_button_handle,
-        rgb_led_indicate::rgb_led_indicate, sweep_ultrasonic::ultrasonic_sweep, track_inactivity::track_inactivity,
+        autonomous_drive::autonomous_drive,
+        battery_charge_read::battery_charge_read,
+        display::display,
+        drive::drive,
+        encoder_read::{self, encoder_read},
+        imu_read::inertial_measurement_read,
+        ir_obstacle_detect::ir_obstacle_detect,
+        monitor_motion::motion_correction_control,
+        orchestrate::orchestrate,
+        rc_control::rc_button_handle,
+        rgb_led_indicate::rgb_led_indicate,
+        sweep_ultrasonic::{self, ultrasonic_sweep},
+        track_inactivity::track_inactivity,
     },
 };
 
@@ -72,39 +81,49 @@ async fn main(spawner: Spawner) {
     spawner.must_spawn(rgb_led_indicate(pwm_red, pwm_green));
 
     // RC button A
-    let btn_a = p.PIN_10;
-    spawner.must_spawn(rc_button_handle(btn_a.into(), ButtonId::A));
+    let btn_a = Input::new(p.PIN_10, Pull::Down);
+    spawner.must_spawn(rc_button_handle(btn_a, ButtonId::A));
 
     // RC button B
-    let btn_b = p.PIN_16;
-    spawner.must_spawn(rc_button_handle(btn_b.into(), ButtonId::B));
+    let btn_b = Input::new(p.PIN_16, Pull::Down);
+    spawner.must_spawn(rc_button_handle(btn_b, ButtonId::B));
 
     // RC button C
-    let btn_c = p.PIN_11;
-    spawner.must_spawn(rc_button_handle(btn_c.into(), ButtonId::C));
+    let btn_c = Input::new(p.PIN_11, Pull::Down);
+    spawner.must_spawn(rc_button_handle(btn_c, ButtonId::C));
 
     // RC button D
-    let btn_d = p.PIN_17;
-    spawner.must_spawn(rc_button_handle(btn_d.into(), ButtonId::D));
+    let btn_d = Input::new(p.PIN_17, Pull::Down);
+    spawner.must_spawn(rc_button_handle(btn_d, ButtonId::D));
 
     // Motor driver
     let motor_standby = Output::new(p.PIN_22, Level::Low);
-    let left_pwm_slice = p.PWM_SLICE6;
-    let left_pwm_pin = p.PIN_28;
+
+    // Configure PWM for motor control at 10kHz
+    let desired_freq_hz = 10_000u32;
+    let clock_freq_hz = embassy_rp::clocks::clk_sys_freq();
+    let divider = ((clock_freq_hz / desired_freq_hz) / 65535 + 1) as u8;
+    let period = (clock_freq_hz / (desired_freq_hz * divider as u32)) as u16 - 1;
+    let mut motor_pwm_config = embassy_rp::pwm::Config::default();
+    motor_pwm_config.divider = divider.into();
+    motor_pwm_config.top = period;
+
+    // Create configured PWM outputs for motors
+    let left_pwm = embassy_rp::pwm::Pwm::new_output_a(p.PWM_SLICE6, p.PIN_28, motor_pwm_config.clone());
+    let right_pwm = embassy_rp::pwm::Pwm::new_output_b(p.PWM_SLICE5, p.PIN_27, motor_pwm_config);
+
+    // Create direction control GPIO pins
     let left_forward = Output::new(p.PIN_21, Level::Low);
     let left_backward = Output::new(p.PIN_20, Level::Low);
-    let right_pwm_slice = p.PWM_SLICE5;
-    let right_pwm_pin = p.PIN_27;
     let right_forward = Output::new(p.PIN_19, Level::Low);
     let right_backward = Output::new(p.PIN_18, Level::Low);
+
     spawner.must_spawn(drive(
         motor_standby,
-        left_pwm_slice,
-        left_pwm_pin,
+        left_pwm,
         left_forward,
         left_backward,
-        right_pwm_slice,
-        right_pwm_pin,
+        right_pwm,
         right_forward,
         right_backward,
     ));
@@ -113,16 +132,15 @@ async fn main(spawner: Spawner) {
     spawner.must_spawn(autonomous_drive());
 
     // IR obstacle detection
-    let ir_left = p.PIN_6;
-    let ir_right = p.PIN_26;
-    spawner.must_spawn(ir_obstacle_detect(ir_left, ir_right));
+    let ir_right = Input::new(p.PIN_26, Pull::Down);
+    spawner.must_spawn(ir_obstacle_detect(ir_right));
 
     // Ultrasonic sensor sweep
-    let servo_pio = p.PIO0;
-    let servo_pin = p.PIN_5;
-    let us_trigger = p.PIN_15;
-    let us_echo = p.PIN_14;
-    spawner.must_spawn(ultrasonic_sweep(servo_pio, servo_pin, us_trigger, us_echo));
+    let us_trigger = Output::new(p.PIN_15, Level::Low);
+    let us_echo = Input::new(p.PIN_14, Pull::None);
+    let sensor = sweep_ultrasonic::setup_ultrasonic_sensor(us_trigger, us_echo);
+    let servo = sweep_ultrasonic::setup_servo(p.PIO0, p.PIN_5);
+    spawner.must_spawn(ultrasonic_sweep(sensor, servo));
 
     // I2C bus (shared between display and IMU)
     let mut i2c_config = I2cConfig::default();
@@ -135,16 +153,22 @@ async fn main(spawner: Spawner) {
     spawner.must_spawn(display(i2c_bus));
 
     // Motor encoders
-    let left_encoder_slice = p.PWM_SLICE3;
-    let left_encoder_pin = p.PIN_7;
-    let right_encoder_slice = p.PWM_SLICE4;
-    let right_encoder_pin = p.PIN_9;
-    spawner.must_spawn(encoder_read(
-        left_encoder_slice,
-        left_encoder_pin,
-        right_encoder_slice,
-        right_encoder_pin,
-    ));
+    let encoder_pwm_config = encoder_read::configure_encoder_pwm();
+    let left_encoder = Pwm::new_input(
+        p.PWM_SLICE3,
+        p.PIN_7,
+        Pull::None,
+        InputMode::RisingEdge,
+        encoder_pwm_config.clone(),
+    );
+    let right_encoder = Pwm::new_input(
+        p.PWM_SLICE4,
+        p.PIN_9,
+        Pull::None,
+        InputMode::RisingEdge,
+        encoder_pwm_config,
+    );
+    spawner.must_spawn(encoder_read(left_encoder, right_encoder));
 
     // IMU (Inertial Measurement Unit)
     let imu_int = p.PIN_8;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@
 use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_rp::{
+    Peri,
     adc::{Adc, Channel, Config as AdcConfig, InterruptHandler as AdcInterruptHandler},
     bind_interrupts,
     block::ImageDef,
@@ -64,42 +65,107 @@ pub type I2cBusShared = Mutex<CriticalSectionRawMutex, I2c<'static, I2C0, embass
 /// Firmware entry point
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
-    let p = embassy_rp::init(Config::default());
+    // Configure rp2350 to use the external oscillator and run at its usual 150Mhz
+    let mut config = Config::default();
+    config.clocks = embassy_rp::clocks::ClockConfig::system_freq(150_000_000).unwrap();
+    let p = embassy_rp::init(config);
 
-    // Orchestrator task
+    // make peripheral handles and spawn tasks
+    init_orchestrate(&spawner);
+    init_battery_monitoring(&spawner, p.ADC, p.PIN_29);
+    init_rgb_led(&spawner, p.PWM_SLICE1, p.PIN_2, p.PWM_SLICE2, p.PIN_4);
+    init_rc_buttons(&spawner, p.PIN_10, p.PIN_16, p.PIN_11, p.PIN_17);
+    init_motor_driver(
+        &spawner,
+        p.PWM_SLICE6,
+        p.PIN_28,
+        p.PWM_SLICE5,
+        p.PIN_27,
+        p.PIN_22,
+        p.PIN_21,
+        p.PIN_20,
+        p.PIN_19,
+        p.PIN_18,
+    );
+    init_autonomous_drive(&spawner);
+    init_ir_obstacle_detect(&spawner, p.PIN_26);
+    init_ultrasonic_sweep(&spawner, p.PIO0, p.PIN_5, p.PIN_15, p.PIN_14);
+    let i2c_bus = init_i2c_bus(p.I2C0, p.PIN_13, p.PIN_12);
+    init_display(&spawner, i2c_bus);
+    init_imu_read(&spawner, i2c_bus, p.PIN_8, p.PIN_3);
+    init_encoder_read(&spawner, p.PWM_SLICE3, p.PIN_7, p.PWM_SLICE4, p.PIN_9);
+    init_motion_correction(&spawner);
+    init_inactivity_tracker(&spawner);
+
+    // main wishes you a great day
+}
+
+/// Initialize orchestrator task
+fn init_orchestrate(spawner: &Spawner) {
     spawner.must_spawn(orchestrate());
+}
 
-    // Battery monitoring
-    let adc = Adc::new(p.ADC, Irqs, AdcConfig::default());
-    let vsys_channel = Channel::new_pin(p.PIN_29, Pull::None);
+/// Initialize battery monitoring task with ADC
+fn init_battery_monitoring(
+    spawner: &Spawner,
+    adc: Peri<'static, embassy_rp::peripherals::ADC>,
+    pin_29: Peri<'static, embassy_rp::peripherals::PIN_29>,
+) {
+    let adc = Adc::new(adc, Irqs, AdcConfig::default());
+    let vsys_channel = Channel::new_pin(pin_29, Pull::None);
     spawner.must_spawn(battery_charge_read(adc, vsys_channel));
+}
 
-    // RGB LED indicator
-    let pwm_red_config = embassy_rp::pwm::Config::default();
-    let pwm_red = Pwm::new_output_a(p.PWM_SLICE1, p.PIN_2, pwm_red_config.clone());
-    let pwm_green = Pwm::new_output_a(p.PWM_SLICE2, p.PIN_4, pwm_red_config.clone());
+/// Initialize RGB LED indicator with PWM outputs
+fn init_rgb_led(
+    spawner: &Spawner,
+    pwm_slice1: Peri<'static, embassy_rp::peripherals::PWM_SLICE1>,
+    pin_2: Peri<'static, embassy_rp::peripherals::PIN_2>,
+    pwm_slice2: Peri<'static, embassy_rp::peripherals::PWM_SLICE2>,
+    pin_4: Peri<'static, embassy_rp::peripherals::PIN_4>,
+) {
+    let pwm_config = embassy_rp::pwm::Config::default();
+    let pwm_red = Pwm::new_output_a(pwm_slice1, pin_2, pwm_config.clone());
+    let pwm_green = Pwm::new_output_a(pwm_slice2, pin_4, pwm_config);
     spawner.must_spawn(rgb_led_indicate(pwm_red, pwm_green));
+}
 
-    // RC button A
-    let btn_a = Input::new(p.PIN_10, Pull::Down);
+/// Initialize all four RC button inputs
+fn init_rc_buttons(
+    spawner: &Spawner,
+    pin_10: Peri<'static, embassy_rp::peripherals::PIN_10>,
+    pin_16: Peri<'static, embassy_rp::peripherals::PIN_16>,
+    pin_11: Peri<'static, embassy_rp::peripherals::PIN_11>,
+    pin_17: Peri<'static, embassy_rp::peripherals::PIN_17>,
+) {
+    let btn_a = Input::new(pin_10, Pull::Down);
     spawner.must_spawn(rc_button_handle(btn_a, ButtonId::A));
 
-    // RC button B
-    let btn_b = Input::new(p.PIN_16, Pull::Down);
+    let btn_b = Input::new(pin_16, Pull::Down);
     spawner.must_spawn(rc_button_handle(btn_b, ButtonId::B));
 
-    // RC button C
-    let btn_c = Input::new(p.PIN_11, Pull::Down);
+    let btn_c = Input::new(pin_11, Pull::Down);
     spawner.must_spawn(rc_button_handle(btn_c, ButtonId::C));
 
-    // RC button D
-    let btn_d = Input::new(p.PIN_17, Pull::Down);
+    let btn_d = Input::new(pin_17, Pull::Down);
     spawner.must_spawn(rc_button_handle(btn_d, ButtonId::D));
+}
 
-    // Motor driver
-    let motor_standby = Output::new(p.PIN_22, Level::Low);
+/// Initialize motor driver with PWM and direction control
+fn init_motor_driver(
+    spawner: &Spawner,
+    pwm_slice6: Peri<'static, embassy_rp::peripherals::PWM_SLICE6>,
+    pin_28: Peri<'static, embassy_rp::peripherals::PIN_28>,
+    pwm_slice5: Peri<'static, embassy_rp::peripherals::PWM_SLICE5>,
+    pin_27: Peri<'static, embassy_rp::peripherals::PIN_27>,
+    pin_22: Peri<'static, embassy_rp::peripherals::PIN_22>,
+    pin_21: Peri<'static, embassy_rp::peripherals::PIN_21>,
+    pin_20: Peri<'static, embassy_rp::peripherals::PIN_20>,
+    pin_19: Peri<'static, embassy_rp::peripherals::PIN_19>,
+    pin_18: Peri<'static, embassy_rp::peripherals::PIN_18>,
+) {
+    let motor_standby = Output::new(pin_22, Level::Low);
 
-    // Configure PWM for motor control at 10kHz
     let desired_freq_hz = 10_000u32;
     let clock_freq_hz = embassy_rp::clocks::clk_sys_freq();
     let divider = ((clock_freq_hz / desired_freq_hz) / 65535 + 1) as u8;
@@ -108,15 +174,13 @@ async fn main(spawner: Spawner) {
     motor_pwm_config.divider = divider.into();
     motor_pwm_config.top = period;
 
-    // Create configured PWM outputs for motors
-    let left_pwm = embassy_rp::pwm::Pwm::new_output_a(p.PWM_SLICE6, p.PIN_28, motor_pwm_config.clone());
-    let right_pwm = embassy_rp::pwm::Pwm::new_output_b(p.PWM_SLICE5, p.PIN_27, motor_pwm_config);
+    let left_pwm = Pwm::new_output_a(pwm_slice6, pin_28, motor_pwm_config.clone());
+    let right_pwm = Pwm::new_output_b(pwm_slice5, pin_27, motor_pwm_config);
 
-    // Create direction control GPIO pins
-    let left_forward = Output::new(p.PIN_21, Level::Low);
-    let left_backward = Output::new(p.PIN_20, Level::Low);
-    let right_forward = Output::new(p.PIN_19, Level::Low);
-    let right_backward = Output::new(p.PIN_18, Level::Low);
+    let left_forward = Output::new(pin_21, Level::Low);
+    let left_backward = Output::new(pin_20, Level::Low);
+    let right_forward = Output::new(pin_19, Level::Low);
+    let right_backward = Output::new(pin_18, Level::Low);
 
     spawner.must_spawn(drive(
         motor_standby,
@@ -127,57 +191,88 @@ async fn main(spawner: Spawner) {
         right_forward,
         right_backward,
     ));
+}
 
-    // Autonomous drive task
-    spawner.must_spawn(autonomous_drive());
-
-    // IR obstacle detection
-    let ir_right = Input::new(p.PIN_26, Pull::Down);
+/// Initialize IR obstacle detection
+fn init_ir_obstacle_detect(spawner: &Spawner, pin_26: Peri<'static, embassy_rp::peripherals::PIN_26>) {
+    let ir_right = Input::new(pin_26, Pull::Down);
     spawner.must_spawn(ir_obstacle_detect(ir_right));
+}
 
-    // Ultrasonic sensor sweep
-    let us_trigger = Output::new(p.PIN_15, Level::Low);
-    let us_echo = Input::new(p.PIN_14, Pull::None);
+/// Initialize ultrasonic sensor sweep with servo
+fn init_ultrasonic_sweep(
+    spawner: &Spawner,
+    pio0: Peri<'static, PIO0>,
+    pin_5: Peri<'static, embassy_rp::peripherals::PIN_5>,
+    pin_15: Peri<'static, embassy_rp::peripherals::PIN_15>,
+    pin_14: Peri<'static, embassy_rp::peripherals::PIN_14>,
+) {
+    let us_trigger = Output::new(pin_15, Level::Low);
+    let us_echo = Input::new(pin_14, Pull::None);
     let sensor = sweep_ultrasonic::setup_ultrasonic_sensor(us_trigger, us_echo);
-    let servo = sweep_ultrasonic::setup_servo(p.PIO0, p.PIN_5);
+    let servo = sweep_ultrasonic::setup_servo(pio0, pin_5);
     spawner.must_spawn(ultrasonic_sweep(sensor, servo));
+}
 
-    // I2C bus (shared between display and IMU)
+/// Initialize shared I2C bus for display and IMU
+fn init_i2c_bus(
+    i2c0: Peri<'static, I2C0>,
+    pin_13: Peri<'static, embassy_rp::peripherals::PIN_13>,
+    pin_12: Peri<'static, embassy_rp::peripherals::PIN_12>,
+) -> &'static I2cBusShared {
     let mut i2c_config = I2cConfig::default();
     i2c_config.frequency = 400_000;
-    let i2c = I2c::new_async(p.I2C0, p.PIN_13, p.PIN_12, Irqs, i2c_config);
+    let i2c = I2c::new_async(i2c0, pin_13, pin_12, Irqs, i2c_config);
     static I2C_BUS: StaticCell<I2cBusShared> = StaticCell::new();
-    let i2c_bus = I2C_BUS.init(Mutex::new(i2c));
+    I2C_BUS.init(Mutex::new(i2c))
+}
 
-    // Display
+/// Initialize display task with I2C bus
+fn init_display(spawner: &Spawner, i2c_bus: &'static I2cBusShared) {
     spawner.must_spawn(display(i2c_bus));
+}
 
-    // Motor encoders
+/// Initialize IMU task with I2C bus and pins
+fn init_imu_read(
+    spawner: &Spawner,
+    i2c_bus: &'static I2cBusShared,
+    pin_8: Peri<'static, embassy_rp::peripherals::PIN_8>,
+    pin_3: Peri<'static, embassy_rp::peripherals::PIN_3>,
+) {
+    spawner.must_spawn(inertial_measurement_read(i2c_bus, pin_8, pin_3));
+}
+
+/// Initialize autonomous drive task
+fn init_autonomous_drive(spawner: &Spawner) {
+    spawner.must_spawn(autonomous_drive());
+}
+
+/// Initialize motor encoder inputs
+fn init_encoder_read(
+    spawner: &Spawner,
+    pwm_slice3: Peri<'static, embassy_rp::peripherals::PWM_SLICE3>,
+    pin_7: Peri<'static, embassy_rp::peripherals::PIN_7>,
+    pwm_slice4: Peri<'static, embassy_rp::peripherals::PWM_SLICE4>,
+    pin_9: Peri<'static, embassy_rp::peripherals::PIN_9>,
+) {
     let encoder_pwm_config = encoder_read::configure_encoder_pwm();
     let left_encoder = Pwm::new_input(
-        p.PWM_SLICE3,
-        p.PIN_7,
+        pwm_slice3,
+        pin_7,
         Pull::None,
         InputMode::RisingEdge,
         encoder_pwm_config.clone(),
     );
-    let right_encoder = Pwm::new_input(
-        p.PWM_SLICE4,
-        p.PIN_9,
-        Pull::None,
-        InputMode::RisingEdge,
-        encoder_pwm_config,
-    );
+    let right_encoder = Pwm::new_input(pwm_slice4, pin_9, Pull::None, InputMode::RisingEdge, encoder_pwm_config);
     spawner.must_spawn(encoder_read(left_encoder, right_encoder));
+}
 
-    // IMU (Inertial Measurement Unit)
-    let imu_int = p.PIN_8;
-    let imu_add = p.PIN_3;
-    spawner.must_spawn(inertial_measurement_read(i2c_bus, imu_int, imu_add));
-
-    // Motion correction control
+/// Initialize motion correction control task
+fn init_motion_correction(spawner: &Spawner) {
     spawner.must_spawn(motion_correction_control());
+}
 
-    // Inactivity tracker
+/// Initialize inactivity tracker task
+fn init_inactivity_tracker(spawner: &Spawner) {
     spawner.must_spawn(track_inactivity());
 }

--- a/src/task/ir_obstacle_detect.rs
+++ b/src/task/ir_obstacle_detect.rs
@@ -13,11 +13,7 @@
 //! - But we have inverted the sensor output in hardware
 //! - Edge detection ensures immediate response to changes
 
-use embassy_rp::{
-    Peri,
-    gpio::{Input, Pull},
-    peripherals::{PIN_6, PIN_26},
-};
+use embassy_rp::gpio::Input;
 use embassy_time::{Duration, Timer};
 
 use crate::system::event::{Events, send_event};
@@ -30,11 +26,7 @@ const DEBOUNCE_DELAY: Duration = Duration::from_millis(100);
 /// Uses edge detection to respond to changes in sensor state, with debouncing
 /// to filter out noise. The sensor outputs low (0) when an obstacle is detected.
 #[embassy_executor::task]
-pub async fn ir_obstacle_detect(_ir_left_pin: Peri<'static, PIN_6>, ir_right_pin: Peri<'static, PIN_26>) {
-    // Initialize IR sensor pin as digital input, with pull-down resistor. No actual floating condition is expected, as long as
-    // the sensor(s) are connected properly, since they will always be either high or low.
-    let mut ir_right = Input::new(ir_right_pin, Pull::Down);
-
+pub async fn ir_obstacle_detect(mut ir_right: Input<'static>) {
     // perform initial measure to ensure initial state is caught
     Timer::after(DEBOUNCE_DELAY).await;
 

--- a/src/task/rc_control.rs
+++ b/src/task/rc_control.rs
@@ -4,10 +4,7 @@
 
 use defmt::info;
 use embassy_futures::select::{Either, select};
-use embassy_rp::{
-    Peri,
-    gpio::{AnyPin, Input, Level, Pull},
-};
+use embassy_rp::gpio::{Input, Level};
 use embassy_time::{Duration, Timer};
 
 use crate::system::event::{ButtonId, Events, send_event};
@@ -20,8 +17,7 @@ const DEBOUNCE_DURATION: Duration = Duration::from_millis(30);
 
 /// Button handler task
 #[embassy_executor::task(pool_size = 4)]
-pub async fn rc_button_handle(pin: Peri<'static, AnyPin>, id: ButtonId) {
-    let mut btn = Input::new(pin, Pull::Down);
+pub async fn rc_button_handle(mut btn: Input<'static>, id: ButtonId) {
     handle_button(&mut btn, id).await;
 }
 


### PR DESCRIPTION
Refactor to construct all peripheral handles in main.
Make dedicated fn for each task we spawn.
Switch to dedicated system frequency to get external oscillator and make it easier to overclock, should we later need that.