### PR TITLE
Run Clippy with default and all features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,17 @@ jobs:
       - name: Check formatting
         run: cargo +nightly fmt --all -- --check
 
-      - name: Run clippy
+      - name: Run clippy (default features)
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --target thumbv8m.main-none-eabihf -- -D warnings -A dead_code
+          args: --target thumbv8m.main-none-eabihf -- -D warnings
+
+      - name: Run clippy (all features)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --target thumbv8m.main-none-eabihf --all-features -- -D warnings
 
       - name: Build
         uses: actions-rs/cargo@v1

--- a/src/task/battery_charge_read.rs
+++ b/src/task/battery_charge_read.rs
@@ -106,18 +106,23 @@ pub async fn battery_charge_read(mut adc: Adc<'static, AdcAsync>, mut channel: C
             (voltage - BATTERY_VOLTAGE_LOWER) / (BATTERY_VOLTAGE_UPPER - BATTERY_VOLTAGE_LOWER)
         };
 
+        let battery_percent_f32: f32 = (battery_level * 100.0).clamp(0.0, 100.0);
+
+        // Convert to integer percentage for events (0..=100).
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let battery_percent: u8 = battery_percent_f32 as u8;
+
         defmt::debug!(
             "Battery: ADC raw={}, voltage={}V, level={}%",
             adc_raw,
             voltage,
-            (battery_level * 100.0) as u8
+            battery_percent_f32
         );
 
         // Send consolidated battery measurement event (single event instead of two)
         // Battery monitoring is critical for safety - must not drop events
         event::raise_event(event::Events::BatteryMeasured {
-            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-            level: (battery_level * 100.0) as u8,
+            level: battery_percent,
             voltage,
         })
         .await;

--- a/src/task/display.rs
+++ b/src/task/display.rs
@@ -62,6 +62,7 @@ enum DisplayError {
     DrawError,
 }
 
+/// SSD1306 display driver type used by the display task.
 type DisplayDriver = Ssd1306<
     I2CInterface<
         I2cDevice<

--- a/src/task/imu_read.rs
+++ b/src/task/imu_read.rs
@@ -163,6 +163,7 @@ pub enum AhrsFusionMode {
     Axis9,
 }
 
+/// Control commands sent to the IMU task.
 enum ImuCommand {
     /// Start IMU readings
     Start,


### PR DESCRIPTION
Split clippy into two runs: default features (removed -A dead_code) and an --all-features run. Treat warnings as errors.