### PR TITLE
Route encoder button via expander

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,14 +91,13 @@ struct RgbLedPins {
 }
 
 /// EC11 rotary encoder pins
+///
+/// Note: Button pin is connected to the port expander and handled there
 struct Ec11Pins {
     /// Pin A
     a: Peri<'static, embassy_rp::peripherals::PIN_10>,
     /// Pin B
     b: Peri<'static, embassy_rp::peripherals::PIN_11>,
-    /// Button pin
-    // ToDo: route through port expander!
-    button: Peri<'static, embassy_rp::peripherals::PIN_24>,
 }
 
 /// RC Control button pins
@@ -209,7 +208,6 @@ async fn main(spawner: Spawner) {
         Ec11Pins {
             a: p.PIN_10,
             b: p.PIN_11,
-            button: p.PIN_24,
         },
     );
 
@@ -316,25 +314,24 @@ fn init_rotary_encoder(
 ) {
     let encoder_program = PioEncoderProgram::new(common);
     let encoder = PioEncoder::new(common, sm3, pins.a, pins.b, &encoder_program);
-    let encoder_button = Input::new(pins.button, Pull::Up);
 
     spawner.must_spawn(task::rotary_encoder::rotary_encoder_turns(encoder));
-    spawner.must_spawn(task::rotary_encoder::rotary_encoder_button(encoder_button));
+    spawner.must_spawn(task::rotary_encoder::rotary_encoder_button());
 }
 
 /// Initialize all four RC button inputs
 fn init_rc_buttons(spawner: Spawner, pins: RCButtonPins) {
     let btn_a = Input::new(pins.a, Pull::Down);
-    spawner.must_spawn(task::rc_control::rc_button_handle(btn_a, system::event::ButtonId::A));
+    spawner.must_spawn(task::rc_control::rc_button_handle(btn_a, system::event::RCButtonId::A));
 
     let btn_b = Input::new(pins.b, Pull::Down);
-    spawner.must_spawn(task::rc_control::rc_button_handle(btn_b, system::event::ButtonId::B));
+    spawner.must_spawn(task::rc_control::rc_button_handle(btn_b, system::event::RCButtonId::B));
 
     let btn_c = Input::new(pins.c, Pull::Down);
-    spawner.must_spawn(task::rc_control::rc_button_handle(btn_c, system::event::ButtonId::C));
+    spawner.must_spawn(task::rc_control::rc_button_handle(btn_c, system::event::RCButtonId::C));
 
     let btn_d = Input::new(pins.d, Pull::Down);
-    spawner.must_spawn(task::rc_control::rc_button_handle(btn_d, system::event::ButtonId::D));
+    spawner.must_spawn(task::rc_control::rc_button_handle(btn_d, system::event::RCButtonId::D));
 }
 
 /// Initialize motor driver with PWM channels and encoders

--- a/src/system/event.rs
+++ b/src/system/event.rs
@@ -99,20 +99,20 @@ pub enum Events {
         voltage: f32,
     },
 
-    /// Button press detected
+    /// RC Button press detected
     /// - Short press (< 1 second)
     /// - Maps to immediate actions
-    ButtonPressed(ButtonId),
+    RCButtonPressed(RCButtonId),
 
     /// Button hold initiated
     /// - Long press started
     /// - Used for mode changes
-    ButtonHoldStart(ButtonId),
+    ButtonHoldStart(RCButtonId),
 
     /// Button hold released
     /// - Long press ended
     /// - Completes hold actions
-    ButtonHoldEnd(ButtonId),
+    ButtonHoldEnd(RCButtonId),
 
     /// Rotary encoder turn
     /// - Clockwise = increment, `CounterClockwise` = decrement
@@ -191,7 +191,7 @@ pub enum RotaryDirection {
 
 /// Remote control button identifiers
 #[derive(Debug, Clone, Copy, Format, Eq, PartialEq)]
-pub enum ButtonId {
+pub enum RCButtonId {
     /// Forward/Mode toggle button
     A,
     /// Right turn button

--- a/src/task/orchestrate.rs
+++ b/src/task/orchestrate.rs
@@ -42,7 +42,7 @@ async fn handle_event(event: Events) {
         Events::ObstacleDetected(detected) => handle_obstacle_detected(detected).await,
         Events::ObstacleAvoidanceAttempted => handle_obstacle_avoidance_attempted().await,
         Events::BatteryMeasured { level, voltage } => handle_battery_measured(level, voltage).await,
-        Events::ButtonPressed(button_id) => handle_button_pressed(button_id).await,
+        Events::RCButtonPressed(button_id) => handle_button_pressed(button_id).await,
         Events::ButtonHoldStart(button_id) => handle_button_hold_start(button_id).await,
         Events::ButtonHoldEnd(button_id) => handle_button_hold_end(button_id).await,
         Events::RotaryTurned(_) => info!("Rotary turned"),
@@ -231,7 +231,7 @@ async fn handle_obstacle_avoidance_attempted() {
 
 /// Handle button press events
 #[allow(clippy::unused_async)]
-async fn handle_button_pressed(_button_id: crate::system::event::ButtonId) {
+async fn handle_button_pressed(_button_id: crate::system::event::RCButtonId) {
     info!("Button pressed");
     // TODO: Implement button actions
     // - Map to drive commands
@@ -240,7 +240,7 @@ async fn handle_button_pressed(_button_id: crate::system::event::ButtonId) {
 
 /// Handle button hold start events
 #[allow(clippy::unused_async)]
-async fn handle_button_hold_start(_button_id: crate::system::event::ButtonId) {
+async fn handle_button_hold_start(_button_id: crate::system::event::RCButtonId) {
     info!("Button hold started");
     // TODO: Implement hold start actions
     // - Prepare for mode change
@@ -249,7 +249,7 @@ async fn handle_button_hold_start(_button_id: crate::system::event::ButtonId) {
 
 /// Handle button hold end events
 #[allow(clippy::unused_async)]
-async fn handle_button_hold_end(_button_id: crate::system::event::ButtonId) {
+async fn handle_button_hold_end(_button_id: crate::system::event::RCButtonId) {
     info!("Button hold ended");
     // TODO: Implement hold end actions
     // - Complete mode change

--- a/src/task/port_expander.rs
+++ b/src/task/port_expander.rs
@@ -54,8 +54,8 @@ use embedded_hal_async::i2c::I2c;
 
 use crate::{
     I2cBusShared,
-    system::event::{ButtonId, Events, raise_event},
-    task::ir_obstacle_detect::signal_ir_obstacle,
+    system::event::{Events, RCButtonId, raise_event},
+    task::{ir_obstacle_detect::signal_ir_obstacle, rotary_encoder::trigger_button_signal},
 };
 
 /// PCA9555 I2C address (A0=high, A1=A2=low -> 0x21)
@@ -136,16 +136,18 @@ pub enum PortExpanderCommand {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Format)]
 struct InputState {
-    /// Button A (active-low in hardware).
-    button_a: bool,
-    /// Button B (active-low in hardware).
-    button_b: bool,
-    /// Button C (active-low in hardware).
-    button_c: bool,
-    /// Button D (active-low in hardware).
-    button_d: bool,
+    /// RC Button A (active-low in hardware).
+    rc_button_a: bool,
+    /// RC Button B (active-low in hardware).
+    rc_button_b: bool,
+    /// RC Button C (active-low in hardware).
+    rc_button_c: bool,
+    /// RC Button D (active-low in hardware).
+    rc_button_d: bool,
     /// IR obstacle signal (active-high in hardware).
     ir_obstacle: bool,
+    /// Rotary encoder push button (active-low in hardware).
+    rotary_encoder_button: bool,
 }
 
 impl InputState {
@@ -153,31 +155,36 @@ impl InputState {
     /// Note: RC buttons are inverted by NOT gates in hardware (active-LOW)
     const fn from_port1(value: u8) -> Self {
         Self {
-            button_a: (value & 0b0000_0001) == 0, // Inverted: LOW = pressed
-            button_b: (value & 0b0000_0010) == 0, // Inverted: LOW = pressed
-            button_c: (value & 0b0000_0100) == 0, // Inverted: LOW = pressed
-            button_d: (value & 0b0000_1000) == 0, // Inverted: LOW = pressed
+            rc_button_a: (value & 0b0000_0001) == 0, // Inverted: LOW = pressed
+            rc_button_b: (value & 0b0000_0010) == 0, // Inverted: LOW = pressed
+            rc_button_c: (value & 0b0000_0100) == 0, // Inverted: LOW = pressed
+            rc_button_d: (value & 0b0000_1000) == 0, // Inverted: LOW = pressed
             // IR sensor output is inverted in hardware: HIGH = obstacle detected
             ir_obstacle: (value & 0b0100_0000) != 0,
+            // Rotary encoder button is inverted: LOW = pressed
+            rotary_encoder_button: (value & 0b1000_0000) == 0,
         }
     }
 
     /// Compare and send events for changed inputs
     async fn send_changes(&self, previous: &Self) {
-        if self.button_a != previous.button_a && self.button_a {
-            raise_event(Events::ButtonPressed(ButtonId::A)).await;
+        if self.rc_button_a != previous.rc_button_a && self.rc_button_a {
+            raise_event(Events::RCButtonPressed(RCButtonId::A)).await;
         }
-        if self.button_b != previous.button_b && self.button_b {
-            raise_event(Events::ButtonPressed(ButtonId::B)).await;
+        if self.rc_button_b != previous.rc_button_b && self.rc_button_b {
+            raise_event(Events::RCButtonPressed(RCButtonId::B)).await;
         }
-        if self.button_c != previous.button_c && self.button_c {
-            raise_event(Events::ButtonPressed(ButtonId::C)).await;
+        if self.rc_button_c != previous.rc_button_c && self.rc_button_c {
+            raise_event(Events::RCButtonPressed(RCButtonId::C)).await;
         }
-        if self.button_d != previous.button_d && self.button_d {
-            raise_event(Events::ButtonPressed(ButtonId::D)).await;
+        if self.rc_button_d != previous.rc_button_d && self.rc_button_d {
+            raise_event(Events::RCButtonPressed(RCButtonId::D)).await;
         }
         if self.ir_obstacle != previous.ir_obstacle {
             signal_ir_obstacle(self.ir_obstacle).await;
+        }
+        if self.rotary_encoder_button != previous.rotary_encoder_button {
+            trigger_button_signal(self.rotary_encoder_button).await;
         }
     }
 }
@@ -199,11 +206,12 @@ impl PortExpanderState {
             port0_output: 0x00,
             port1_output: 0x00, // No pull-ups - external pull-downs needed for RC inputs
             last_input_state: InputState {
-                button_a: false,
-                button_b: false,
-                button_c: false,
-                button_d: false,
+                rc_button_a: false,
+                rc_button_b: false,
+                rc_button_c: false,
+                rc_button_d: false,
                 ir_obstacle: false,
+                rotary_encoder_button: false,
             },
         }
     }

--- a/src/task/rc_control.rs
+++ b/src/task/rc_control.rs
@@ -7,7 +7,7 @@ use embassy_futures::select::{Either, select};
 use embassy_rp::gpio::{Input, Level};
 use embassy_time::{Duration, Timer};
 
-use crate::system::event::{ButtonId, Events, raise_event};
+use crate::system::event::{Events, RCButtonId, raise_event};
 
 /// Button hold threshold (ms)
 const HOLD_DURATION: Duration = Duration::from_millis(700);
@@ -17,7 +17,7 @@ const DEBOUNCE_DURATION: Duration = Duration::from_millis(30);
 
 /// Button handler task
 #[embassy_executor::task(pool_size = 4)]
-pub async fn rc_button_handle(mut btn: Input<'static>, id: ButtonId) {
+pub async fn rc_button_handle(mut btn: Input<'static>, id: RCButtonId) {
     handle_button(&mut btn, id).await;
 }
 
@@ -26,7 +26,7 @@ pub async fn rc_button_handle(mut btn: Input<'static>, id: ButtonId) {
 /// Generates:
 /// - `ButtonPressed` for short press
 /// - ButtonHoldStart/End for long press
-async fn handle_button(button: &mut Input<'static>, id: ButtonId) {
+async fn handle_button(button: &mut Input<'static>, id: RCButtonId) {
     loop {
         let init_level = debounce(button).await;
 
@@ -43,7 +43,7 @@ async fn handle_button(button: &mut Input<'static>, id: ButtonId) {
                 raise_event(Events::ButtonHoldEnd(id)).await;
             }
             Either::Second(_) => {
-                raise_event(Events::ButtonPressed(id)).await;
+                raise_event(Events::RCButtonPressed(id)).await;
             }
         }
     }

--- a/src/task/rotary_encoder.rs
+++ b/src/task/rotary_encoder.rs
@@ -7,13 +7,15 @@
 //! Pin plan (per docs):
 //! - GPIO22: Encoder A
 //! - GPIO23: Encoder B
-//! - GPIO24: Encoder button (active-low with pull-up)
+//!
+//! The button is connected to the port expander, so it is read via a signal triggered by the expander's interrupt when the button state changes.
 
 use embassy_futures::select::{Either, select};
 use embassy_rp::{
     gpio::{Input, Level},
     pio_programs::rotary_encoder::{Direction as PioDirection, PioEncoder},
 };
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex, signal::Signal};
 use embassy_time::{Duration, Timer};
 
 use crate::system::event::{Events, RotaryDirection, raise_event};
@@ -23,6 +25,35 @@ const HOLD_DURATION: Duration = Duration::from_millis(700);
 
 /// Button debounce delay (ms)
 const DEBOUNCE_DURATION: Duration = Duration::from_millis(30);
+
+/// Button Signal
+/// Since we are using the port expander for the button, we must use a signal instead of a gpio input directly. The signal will be used to trigger the debounce logic when the button is pressed or released.
+pub static BTN_SIGNAL: Signal<CriticalSectionRawMutex, bool> = Signal::new();
+
+/// Triggers the button signal with the current state of the button (pressed or released). Updates the button state in the mutex and then signals any waiting tasks to wake up and process the new state.
+pub async fn trigger_button_signal(pressed: bool) {
+    // Update the button state
+    {
+        let mut state = BUTTON_STATE.lock().await;
+        state.pressed = pressed;
+    }
+    // Trigger the signal to wake up any waiting tasks
+    BTN_SIGNAL.signal(pressed);
+}
+
+/// Waits for the next button signal
+async fn wait_for_button_signal() {
+    BTN_SIGNAL.wait().await;
+}
+
+/// Button state protected by a mutex
+pub static BUTTON_STATE: Mutex<CriticalSectionRawMutex, ButtonState> = Mutex::new(ButtonState { pressed: false });
+
+/// Represents the current state of the rotary encoder button (pressed or released).
+pub struct ButtonState {
+    /// True if the button is currently pressed, false if released.
+    pub pressed: bool,
+}
 
 /// Task that reads quadrature turns and emits increment/decrement events.
 #[embassy_executor::task]
@@ -39,19 +70,19 @@ pub async fn rotary_encoder_turns(mut encoder: PioEncoder<'static, embassy_rp::p
 
 /// Task that handles the EC11 button (active-low, pull-up enabled).
 #[embassy_executor::task]
-pub async fn rotary_encoder_button(mut button: Input<'static>) {
+pub async fn rotary_encoder_button() {
     loop {
-        let level = debounce(&mut button).await;
+        let pressed = debounce().await;
 
         // Active-low: pressed when LOW.
-        if level != Level::Low {
+        if pressed {
             continue;
         }
 
-        match select(Timer::after(HOLD_DURATION), debounce(&mut button)).await {
+        match select(Timer::after(HOLD_DURATION), debounce()).await {
             Either::First(()) => {
                 raise_event(Events::RotaryButtonHoldStart).await;
-                button.wait_for_high().await;
+                wait_for_released().await;
                 raise_event(Events::RotaryButtonHoldEnd).await;
             }
             Either::Second(_) => {
@@ -62,14 +93,37 @@ pub async fn rotary_encoder_button(mut button: Input<'static>) {
 }
 
 /// Ensures stable button state after any edge.
-async fn debounce(button: &mut Input<'static>) -> Level {
+async fn debounce() -> bool {
     loop {
-        let st_level = button.get_level();
-        button.wait_for_any_edge().await;
+        // what state do we have right now?
+        let st_state = {
+            let mut btn_state = BUTTON_STATE.lock().await;
+            btn_state.pressed
+        };
+
+        // wait for the next signal (edge) to occur
+        wait_for_button_signal().await;
         Timer::after(DEBOUNCE_DURATION).await;
-        let end_level = button.get_level();
-        if st_level != end_level {
-            break end_level;
+        let end_state = {
+            let mut btn_state = BUTTON_STATE.lock().await;
+            btn_state.pressed
+        };
+        if st_state != end_state {
+            break end_state;
         }
+    }
+}
+
+/// Waits until the button is released (active-low means waiting for HIGH).
+async fn wait_for_released() {
+    loop {
+        let pressed = {
+            let mut btn_state = BUTTON_STATE.lock().await;
+            btn_state.pressed
+        };
+        if !pressed {
+            break;
+        }
+        Timer::after(Duration::from_millis(5)).await;
     }
 }

--- a/src/task/rotary_encoder.rs
+++ b/src/task/rotary_encoder.rs
@@ -11,10 +11,7 @@
 //! The button is connected to the port expander, so it is read via a signal triggered by the expander's interrupt when the button state changes.
 
 use embassy_futures::select::{Either, select};
-use embassy_rp::{
-    gpio::{Input, Level},
-    pio_programs::rotary_encoder::{Direction as PioDirection, PioEncoder},
-};
+use embassy_rp::pio_programs::rotary_encoder::{Direction as PioDirection, PioEncoder};
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex, signal::Signal};
 use embassy_time::{Duration, Timer};
 
@@ -26,11 +23,13 @@ const HOLD_DURATION: Duration = Duration::from_millis(700);
 /// Button debounce delay (ms)
 const DEBOUNCE_DURATION: Duration = Duration::from_millis(30);
 
-/// Button Signal
-/// Since we are using the port expander for the button, we must use a signal instead of a gpio input directly. The signal will be used to trigger the debounce logic when the button is pressed or released.
+/// Button signal.
+/// Since we are using the port expander for the button, we must use a signal instead of a GPIO input directly.
+/// The signal is used to trigger the debounce logic when the button is pressed or released.
 pub static BTN_SIGNAL: Signal<CriticalSectionRawMutex, bool> = Signal::new();
 
-/// Triggers the button signal with the current state of the button (pressed or released). Updates the button state in the mutex and then signals any waiting tasks to wake up and process the new state.
+/// Triggers the button signal with the current state of the button (pressed or released).
+/// Updates the button state in the mutex and then signals any waiting tasks to wake up and process the new state.
 pub async fn trigger_button_signal(pressed: bool) {
     // Update the button state
     {
@@ -41,12 +40,12 @@ pub async fn trigger_button_signal(pressed: bool) {
     BTN_SIGNAL.signal(pressed);
 }
 
-/// Waits for the next button signal
+/// Waits for the next button signal.
 async fn wait_for_button_signal() {
     BTN_SIGNAL.wait().await;
 }
 
-/// Button state protected by a mutex
+/// Button state protected by a mutex.
 pub static BUTTON_STATE: Mutex<CriticalSectionRawMutex, ButtonState> = Mutex::new(ButtonState { pressed: false });
 
 /// Represents the current state of the rotary encoder button (pressed or released).
@@ -75,7 +74,7 @@ pub async fn rotary_encoder_button() {
         let pressed = debounce().await;
 
         // Active-low: pressed when LOW.
-        if pressed {
+        if !pressed {
             continue;
         }
 
@@ -95,21 +94,19 @@ pub async fn rotary_encoder_button() {
 /// Ensures stable button state after any edge.
 async fn debounce() -> bool {
     loop {
-        // what state do we have right now?
-        let st_state = {
-            let mut btn_state = BUTTON_STATE.lock().await;
+        // Wait for the next edge from the expander, then verify stable state.
+        wait_for_button_signal().await;
+        Timer::after(DEBOUNCE_DURATION).await;
+
+        let state_after_debounce = {
+            let btn_state = BUTTON_STATE.lock().await;
             btn_state.pressed
         };
 
-        // wait for the next signal (edge) to occur
-        wait_for_button_signal().await;
-        Timer::after(DEBOUNCE_DURATION).await;
-        let end_state = {
-            let mut btn_state = BUTTON_STATE.lock().await;
-            btn_state.pressed
-        };
-        if st_state != end_state {
-            break end_state;
+        // If another edge happened during debounce, keep waiting.
+        let edge_happened_during_debounce = BTN_SIGNAL.signaled();
+        if !edge_happened_during_debounce {
+            break state_after_debounce;
         }
     }
 }
@@ -118,12 +115,12 @@ async fn debounce() -> bool {
 async fn wait_for_released() {
     loop {
         let pressed = {
-            let mut btn_state = BUTTON_STATE.lock().await;
+            let btn_state = BUTTON_STATE.lock().await;
             btn_state.pressed
         };
         if !pressed {
             break;
         }
-        Timer::after(Duration::from_millis(5)).await;
+        wait_for_button_signal().await;
     }
 }


### PR DESCRIPTION
Rename ButtonId and related Events to RCButtonId/RCButton*. Read RC buttons from the PCA9555 and emit RCButton events. Trigger the rotary encoder button through a Signal + Mutex from the port-expander handler and remove direct GPIO handling.