### PR TITLE
Introduce a new system to register and execute drive actions until their

### DIFF
--- a/src/system/button_actions.rs
+++ b/src/system/button_actions.rs
@@ -86,7 +86,7 @@ pub async fn handle_button_action(button_id: event::ButtonId, action_type: Butto
         (event::ButtonId::A, ButtonActionType::Press) => {
             // Drive forward at 20% power
             rgb_led_indicate::update_indicator(true);
-            drive::send_drive_command(DriveCommand::Drive(DriveAction::Forward(20)));
+            drive::send_drive_command(DriveCommand::Drive(DriveAction::Forward(20))).await;
         }
 
         // Button B - Right turn
@@ -96,7 +96,8 @@ pub async fn handle_button_action(button_id: event::ButtonId, action_type: Butto
             drive::send_drive_command(DriveCommand::Drive(DriveAction::TorqueBias {
                 reduce_side: MotorSide::Right,
                 bias_amount: 20,
-            }));
+            }))
+            .await;
         }
         (event::ButtonId::B, ButtonActionType::HoldEnd) => {
             // Precise 90-degree clockwise rotation
@@ -108,7 +109,8 @@ pub async fn handle_button_action(button_id: event::ButtonId, action_type: Butto
                 degrees: 90.0,
                 direction: RotationDirection::Clockwise,
                 motion,
-            }));
+            }))
+            .await;
         }
 
         // Button C - Left turn
@@ -118,7 +120,8 @@ pub async fn handle_button_action(button_id: event::ButtonId, action_type: Butto
             drive::send_drive_command(DriveCommand::Drive(DriveAction::TorqueBias {
                 reduce_side: MotorSide::Left,
                 bias_amount: 20,
-            }));
+            }))
+            .await;
         }
         (event::ButtonId::C, ButtonActionType::HoldEnd) => {
             // Precise 90-degree counter-clockwise rotation
@@ -130,14 +133,15 @@ pub async fn handle_button_action(button_id: event::ButtonId, action_type: Butto
                 degrees: 90.0,
                 direction: RotationDirection::CounterClockwise,
                 motion,
-            }));
+            }))
+            .await;
         }
 
         // Button D - Reverse
         (event::ButtonId::D, ButtonActionType::Press) => {
             // Drive backward at 20% power
             rgb_led_indicate::update_indicator(true);
-            drive::send_drive_command(DriveCommand::Drive(DriveAction::Backward(20)));
+            drive::send_drive_command(DriveCommand::Drive(DriveAction::Backward(20))).await;
         }
 
         // All other button/action combinations have no effect

--- a/src/system/event.rs
+++ b/src/system/event.rs
@@ -160,9 +160,6 @@ pub enum Events {
     ImuMeasurementTaken(ImuMeasurement),
 
     /// Precise rotation completed
-    /// - Signals that a `RotateExact` command finished
-    /// - Used for sequencing movements
-    RotationCompleted,
 
     // /// Motion correction needed
     // /// - Signals that the robot needs to correct its current drive settings

--- a/src/task/autonomous_drive.rs
+++ b/src/task/autonomous_drive.rs
@@ -53,23 +53,23 @@ const TURN_ANGLE_MAX: u8 = 180;
 #[embassy_executor::task]
 pub async fn autonomous_drive() {
     // Initial stop sequence
-    send_drive_command(DriveCommand::Drive(DriveAction::Coast));
+    send_drive_command(DriveCommand::Drive(DriveAction::Coast)).await;
     Timer::after(Duration::from_secs(1)).await;
-    send_drive_command(DriveCommand::Drive(DriveAction::Brake));
+    send_drive_command(DriveCommand::Drive(DriveAction::Brake)).await;
 
     loop {
         match wait().await {
             Command::Initialize => {
-                send_drive_command(DriveCommand::Drive(DriveAction::Coast));
+                send_drive_command(DriveCommand::Drive(DriveAction::Coast)).await;
                 Timer::after(Duration::from_millis(100)).await;
             }
             Command::Start => {
                 info!("Autonomous forward");
-                send_drive_command(DriveCommand::Drive(DriveAction::Forward(FORWARD_SPEED)));
+                send_drive_command(DriveCommand::Drive(DriveAction::Forward(FORWARD_SPEED))).await;
             }
             Command::Stop => {
                 info!("Autonomous stop");
-                send_drive_command(DriveCommand::Drive(DriveAction::Brake));
+                send_drive_command(DriveCommand::Drive(DriveAction::Brake)).await;
                 Timer::after(Duration::from_millis(200)).await;
                 continue;
             }
@@ -78,14 +78,14 @@ pub async fn autonomous_drive() {
 
                 // Emergency Stop
                 info!("emergency stop");
-                send_drive_command(DriveCommand::Drive(DriveAction::Brake));
+                send_drive_command(DriveCommand::Drive(DriveAction::Brake)).await;
                 Timer::after(Duration::from_millis(500)).await;
 
                 // Back up
                 info!("backing up");
-                send_drive_command(DriveCommand::Drive(DriveAction::Backward(REVERSE_SPEED)));
+                send_drive_command(DriveCommand::Drive(DriveAction::Backward(REVERSE_SPEED))).await;
                 Timer::after(BACKUP_DURATION).await;
-                send_drive_command(DriveCommand::Drive(DriveAction::Brake));
+                send_drive_command(DriveCommand::Drive(DriveAction::Brake)).await;
                 Timer::after(Duration::from_millis(100)).await;
 
                 // Random turn
@@ -105,7 +105,8 @@ pub async fn autonomous_drive() {
                     degrees: turn_angle as f32,
                     direction: rotation_direction,
                     motion: rotation_motion,
-                }));
+                }))
+                .await;
 
                 Timer::after(Duration::from_millis(100)).await;
 

--- a/src/task/behavior/motion.rs
+++ b/src/task/behavior/motion.rs
@@ -4,15 +4,6 @@ use defmt::info;
 
 use crate::task::sensors::imu;
 
-/// Handle rotation completion.
-#[allow(clippy::unused_async)]
-pub async fn handle_rotation_completed() {
-    info!("Rotation completed");
-    // TODO: Implement rotation completion logic
-    // - Update display
-    // - Signal next movement phase
-}
-
 /// Handle motion data collection control.
 pub fn handle_start_stop_motion_data(start: bool) {
     info!("Motion data collection control");

--- a/src/task/behavior/sensor_events.rs
+++ b/src/task/behavior/sensor_events.rs
@@ -25,8 +25,7 @@ pub async fn handle_ultrasonic_sweep_reading(distance: f64, angle: f32) {
 }
 
 /// Handle IMU measurements.
-#[allow(clippy::unused_async)]
-pub async fn handle_imu_measurement(measurement: imu::ImuMeasurement) {
+pub fn handle_imu_measurement(measurement: imu::ImuMeasurement) {
     // Forward IMU measurements to drive task for rotation control.
     // Use try_send to avoid blocking orchestrator - IMU data arrives at 100Hz.
     // Dropping occasional measurements is acceptable at this rate.

--- a/src/task/drive/control/mod.rs
+++ b/src/task/drive/control/mod.rs
@@ -3,6 +3,10 @@
 //! This module contains all the control algorithms and state machines
 //! used for precise motion control, including rotation, straight-line
 //! driving, tilt compensation, and motor state management.
+//!
+//! Completion handles are resolved by the drive task (`drive/mod.rs`) after
+//! these control routines report progress or terminal states. The control
+//! modules do not own completion senders.
 
 pub mod motor_state;
 pub mod rotation;

--- a/src/task/drive/control/motor_state.rs
+++ b/src/task/drive/control/motor_state.rs
@@ -57,7 +57,7 @@ impl TrackState {
 
     /// Sets motor speed with tilt compensation
     pub async fn set_speed_with_tilt(&mut self, track: Track, base_speed: i8, tilt_degrees: f32) {
-        let mut tilt_compensation = TiltCompensation::new(0.3, 45.0);
+        let tilt_compensation = TiltCompensation::new(0.3, 45.0);
         let tilt_adjustment = tilt_compensation.calculate_adjustment(tilt_degrees);
         let adjusted = f32::from(base_speed) * (1.0 + tilt_adjustment);
         #[allow(clippy::cast_possible_truncation)]

--- a/src/task/drive/control/rotation.rs
+++ b/src/task/drive/control/rotation.rs
@@ -1,4 +1,7 @@
 //! Rotation control for precise turning maneuvers
+//!
+//! This module only computes rotation state and motor speeds.
+//! Completion is resolved by the drive loop when a rotation step finishes.
 
 use crate::task::{
     drive::types::{

--- a/src/task/drive/feedback.rs
+++ b/src/task/drive/feedback.rs
@@ -2,6 +2,10 @@
 //!
 //! This module manages all sensor data channels and functions for forwarding
 //! measurements from the orchestrator to the drive task.
+//!
+//! These channels are strictly for sensor/calibration data. They are separate
+//! from per-command completion handles, which are resolved by the drive loop
+//! after a command finishes, fails, or is cancelled.
 
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Channel, mutex::Mutex};
 use embassy_time::{Duration, Timer};

--- a/src/task/drive/mod.rs
+++ b/src/task/drive/mod.rs
@@ -1,42 +1,56 @@
-//! High-level drive control and coordination
+//! Drive system coordination and intent execution.
 //!
-//! This module implements the control layer that coordinates between sensing and actuation:
+//! This module owns the drive task and its supporting components. It coordinates
+//! sensor feedback, drive intents, and motor commands without consuming the global
+//! event stream directly.
 //!
 //! # Architecture
 //!
 //! ```text
-//! sensors::encoders     drive (THIS)          motor_driver
-//! ├── Sensing       →   ├── Calibration   →   ├── PWM actuation
-//! └── Pulse counts      ├── Motion control    └── Direction control
-//!                       ├── Feedback loops
-//!                       └── Coordination
+//! sensors::encoders     drive task               motor_driver
+//! ├── Pulse counts  →   ├── Queue/interrupt   →   ├── PWM actuation
+//! └── Feedback          ├── Intent lifecycle      └── Direction control
 //!
-//! sensors::imu      →   drive             →   motor_driver
-//! ├── Orientation       ├── Rotation
+//! sensors::imu      →   drive task               motor_driver
+//! ├── Orientation       ├── Rotation control
 //! └── Angles            └── Stabilization
 //! ```
 //!
-//! # Responsibilities
+//! # Control Flow Overview
 //!
-//! 1. **Motor Calibration**: Orchestrates the calibration procedure by coordinating
-//!    encoder readings with motor commands and saving results to flash
+//! The drive task selects over two sources:
 //!
-//! 2. **Motion Control**: Implements high-level driving behaviors:
-//!    - Direct speed control using `motor_driver`'s -100 to +100 convention
-//!    - Differential steering (different left/right speeds)
-//!    - Precise rotation using IMU feedback
-//!    - Combined rotation + motion maneuvers
+//! - **Regular command queue**: Sequenced drive intents that may take time.
+//! - **Interrupt signal**: Emergency brake/stop/cancel that preempts any intent.
 //!
-//! 3. **Feedback Processing**: Receives sensor data from orchestrator and uses it for:
-//!    - Speed adjustments based on encoder feedback
-//!    - Rotation control using gyroscope/IMU data
-//!    - Tilt compensation for inclines
-//!    - Straight-line correction
+//! When an interrupt arrives, the task cancels the active intent, resolves its
+//! completion (if any), increments an epoch, and discards queued commands that
+//! were stamped before the interrupt.
 //!
-//! 4. **Task Coordination**: Sends commands to lower-level tasks:
-//!    - `motor_driver`: PWM speed and direction commands
-//!    - `sensors::encoders`: Start/stop/reset commands
-//!    - `io::flash_storage`: Save calibration data
+//! # Completion Flow (per-command)
+//!
+//! Completion handles are a fixed-size pool of one-shot completion channels.
+//! A `CompletionHandle` is just an index into that pool (not a channel itself);
+//! the handle stays with the caller while the `CompletionSender` is attached to
+//! a command so the drive loop can resolve it.
+//!
+//! - **Acquire** a `CompletionHandle` from the pool (fixed-size; returns `Exhausted` immediately).
+//! - **Create** a `CompletionSender` from the handle and attach it to the command.
+//! - **Await** completion on the handle; the drive loop resolves it on success,
+//!   failure, or cancellation (interrupts and epoch invalidation yield `Cancelled`).
+//! - **Release** the handle back to the pool after you receive the result to avoid leaks.
+//!
+//! **Typical usage:** `acquire_completion_handle` → `completion_sender` →
+//! `send_drive_command_with_completion` → `wait_for_completion` → `release_completion_handle`.
+//!
+//! # Data Flow
+//!
+//! - Commands are sent by orchestrator or other tasks.
+//! - Sensor feedback is forwarded by orchestrator into dedicated channels.
+//! - Motor commands are issued to `motor_driver`.
+//!
+//! This task does NOT consume the system event channel. Forwarding avoids
+//! multiple tasks competing for events.
 //!
 //! # Speed Convention
 //!
@@ -46,55 +60,22 @@
 //! - **Negative values**: Backward motion
 //! - **Zero**: Coast (freewheel)
 //!
-//! No unnecessary abstraction - the `motor_driver`'s interface is clean and simple.
+//! # Module Index
 //!
-//! # Data Flow
-//!
-//! ## Commands (from orchestrator or other high-level tasks)
-//! ```rust
-//! // Direct speed control
-//! drive::send_drive_command(DriveCommand::Drive(
-//!     DriveAction::SetSpeed { left: 50, right: 50 }
-//! )).await;
-//!
-//! // Differential steering (turn right)
-//! drive::send_drive_command(DriveCommand::Drive(
-//!     DriveAction::SetSpeed { left: 60, right: 40 }
-//! )).await;
-//!
-//! // Calibration
-//! drive::send_drive_command(DriveCommand::RunMotorCalibration).await;
-//! ```
-//!
-//! ## Sensor Feedback (from orchestrator)
-//! ```rust
-//! // Encoder measurements (forwarded by orchestrator from encoder_read events)
-//! drive::send_encoder_measurement(measurement).await;
-//!
-//! // IMU measurements are forwarded by orchestrator into the drive feedback subsystem.
-//! // The drive task can poll them on a timer tick when implementing rotation/tilt control.
-//! ```
-//!
-//! # Important: Event Channel Usage
-//!
-//! This task does NOT directly consume system events. All sensor data is forwarded
-//! by the orchestrator via dedicated channels (`send_encoder_measurement()`) to
-//! prevent multiple tasks from competing for events on the system event channel.
-//!
-//! # Control Modes
-//!
-//! - **Direct Control**: Manual speed commands (-100 to +100 per track)
-//! - **Calibration Mode**: Automated motor matching procedure
-//! - **Rotation Control**: IMU-based precise turning
-//! - **Feedback Control**: Encoder-based speed adjustment (TODO)
-//! - **Straight-Line**: IMU-based drift correction (TODO)
+//! - [`control`]: Intent execution and control-loop state machines.
+//! - [`feedback`]: Sensor input channels and measurement forwarding.
+//! - [`compensation`]: Drift compensation helpers.
+//! - [`calibration`]: Motor and IMU calibration procedures.
+//! - [`types`]: Command, telemetry, and completion types.
 
 #![allow(clippy::too_many_arguments)]
 
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
 use defmt::info;
 use embassy_futures::select::{Either, select};
-use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
-use embassy_time::{Duration, Timer};
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Channel, signal::Signal};
+use embassy_time::{Duration, Instant, Timer};
 
 use crate::{
     system::{
@@ -126,66 +107,174 @@ pub use feedback::{
     send_accel_measurement, send_gyro_measurement, send_mag_measurement, try_send_encoder_measurement,
     try_send_imu_measurement,
 };
-pub use types::{DriveAction, DriveCommand, ImuCalibrationKind};
+pub use types::{
+    CompletionStatus, CompletionTelemetry, DriveAction, DriveCommand, DriveCompletion, ImuCalibrationKind,
+    InterruptKind,
+};
 
-/// Command signal for drive control
-///
-/// Used by orchestrator and other high-level tasks to send drive commands
-static DRIVE_CONTROL: Signal<CriticalSectionRawMutex, DriveCommand> = Signal::new();
+/// Envelope for queued drive commands.
+#[derive(Debug, Clone)]
+struct DriveCommandEnvelope {
+    /// Drive command to execute.
+    command: DriveCommand,
+    /// Optional completion sender for per-command completion reporting.
+    completion: Option<types::CompletionSender>,
+    /// Epoch stamped at enqueue time to cancel stale queued commands.
+    /// Used to resolve completions as `Cancelled` when invalidated by interrupts.
+    epoch: u32,
+}
 
-/// Rotation completion notification
+/// Size of the regular drive command queue.
+const DRIVE_QUEUE_SIZE: usize = 16;
+
+/// Regular command queue for drive intents.
+static DRIVE_QUEUE: Channel<CriticalSectionRawMutex, DriveCommandEnvelope, DRIVE_QUEUE_SIZE> = Channel::new();
+
+/// Interrupt signal for emergency actions.
+static DRIVE_INTERRUPT: Signal<CriticalSectionRawMutex, InterruptKind> = Signal::new();
+
+/// Epoch counter for invalidating stale queued commands after interrupts.
+static CURRENT_EPOCH: AtomicU32 = AtomicU32::new(0);
+
+/// Number of per-command completion channels available.
+const COMPLETION_POOL_SIZE: usize = 16;
+/// Single-slot channel used for per-command completion delivery.
+type CompletionChannel = embassy_sync::channel::Channel<CriticalSectionRawMutex, DriveCompletion, 1>;
+
+/// Pool of completion channels used by callers to await per-command results.
+static COMPLETION_CHANNELS: [CompletionChannel; COMPLETION_POOL_SIZE] = [
+    CompletionChannel::new(),
+    CompletionChannel::new(),
+    CompletionChannel::new(),
+    CompletionChannel::new(),
+    CompletionChannel::new(),
+    CompletionChannel::new(),
+    CompletionChannel::new(),
+    CompletionChannel::new(),
+    CompletionChannel::new(),
+    CompletionChannel::new(),
+    CompletionChannel::new(),
+    CompletionChannel::new(),
+    CompletionChannel::new(),
+    CompletionChannel::new(),
+    CompletionChannel::new(),
+    CompletionChannel::new(),
+];
+
+/// Queue of available completion channel indices.
+static COMPLETION_POOL: Channel<CriticalSectionRawMutex, usize, COMPLETION_POOL_SIZE> = Channel::new();
+/// One-time init guard for seeding the completion pool.
+static COMPLETION_POOL_INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+/// Handle used by callers to await per-command completion.
 ///
-/// Dedicated notification for clients (e.g. testing sequences) that need to await rotation completion
-/// without consuming the system-wide event channel.
-///
-/// We use a bounded channel (queue) rather than a signal so callers can safely await
-/// multiple back-to-back rotations without losing intermediate completions.
+/// This is an index into a fixed pool; it is not a channel itself.
+/// Keep the handle local, pass the associated `CompletionSender` with the command,
+/// await completion, then release the handle back to the pool to avoid exhaustion.
 #[derive(Debug, Clone, Copy)]
-pub struct RotationCompletedInfo {
-    /// IMU yaw at completion (degrees, as reported by `ImuMeasurement`)
-    pub final_yaw_deg: f32,
-    /// Normalized signed angle error (degrees) at completion:
-    ///
-    /// - **Positive**  => overshoot (turned too far)
-    /// - **Negative**  => undershoot (didn't turn enough)
-    /// - **Zero**      => exact (within tolerance)
-    ///
-    /// This is computed as: `accumulated_angle - target_angle` where:
-    /// - `accumulated_angle` is the **magnitude** of rotation achieved so far (always ≥ 0)
-    /// - `target_angle` is the requested magnitude (always ≥ 0)
-    pub angle_error_deg: f32,
+pub struct CompletionHandle {
+    /// Index into the fixed completion channel pool.
+    index: usize,
 }
 
-/// Size of the rotation completion notification queue
-const ROTATION_COMPLETED_QUEUE_SIZE: usize = 8;
-
-/// Dedicated channel for rotation completion notifications
-static ROTATION_COMPLETED_CHANNEL: embassy_sync::channel::Channel<
-    CriticalSectionRawMutex,
-    RotationCompletedInfo,
-    ROTATION_COMPLETED_QUEUE_SIZE,
-> = embassy_sync::channel::Channel::new();
-
-/// Send a drive command for execution
-///
-/// Non-blocking signal delivery for drive commands
-pub fn send_drive_command(command: DriveCommand) {
-    DRIVE_CONTROL.signal(command);
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+/// Errors returned when acquiring a completion handle.
+pub enum CompletionPoolError {
+    /// No completion handles are available in the pool.
+    Exhausted,
 }
 
-/// Wait for the next `RotateExact` completion notification.
-///
-/// This does not consume the global event stream; it is delivered via a dedicated channel
-/// emitted by the drive task.
-///
-/// Returns final yaw and angle error at the moment the controller declared completion.
-pub async fn wait_for_rotation_completed() -> RotationCompletedInfo {
-    ROTATION_COMPLETED_CHANNEL.receiver().receive().await
+/// Send a drive command for execution.
+pub async fn send_drive_command(command: DriveCommand) {
+    send_drive_command_internal(command, None).await;
 }
 
-/// Wait for next drive command (internal use)
-async fn wait() -> DriveCommand {
-    DRIVE_CONTROL.wait().await
+/// Send a drive command with a per-command completion sender.
+///
+/// The sender is attached to the command envelope so the drive loop can resolve it.
+/// Completion delivery is guaranteed because the drive loop awaits the send.
+pub async fn send_drive_command_with_completion(command: DriveCommand, completion: types::CompletionSender) {
+    send_drive_command_internal(command, Some(completion)).await;
+}
+
+/// Send an interrupt that preempts the active intent.
+pub fn send_drive_interrupt(kind: InterruptKind) {
+    DRIVE_INTERRUPT.signal(kind);
+}
+
+/// Enqueue a drive command with an optional completion sender.
+async fn send_drive_command_internal(command: DriveCommand, completion: Option<types::CompletionSender>) {
+    let epoch = CURRENT_EPOCH.load(Ordering::Relaxed);
+    let envelope = DriveCommandEnvelope {
+        command,
+        completion,
+        epoch,
+    };
+    DRIVE_QUEUE.sender().send(envelope).await;
+}
+
+/// Acquire a completion handle from the pool.
+///
+/// This does not wait: if the pool is empty, it returns `CompletionPoolError::Exhausted`.
+/// The pool is fixed-size and initialized lazily on first use.
+pub async fn acquire_completion_handle() -> Result<CompletionHandle, CompletionPoolError> {
+    init_completion_pool_once();
+    let index = COMPLETION_POOL
+        .receiver()
+        .try_receive()
+        .map_err(|_| CompletionPoolError::Exhausted)?;
+    Ok(CompletionHandle { index })
+}
+
+/// Release a completion handle back into the pool.
+///
+/// This drains any stale completion and returns the index to the pool. Call this
+/// after awaiting completion to avoid leaking handles and exhausting the pool.
+pub async fn release_completion_handle(handle: CompletionHandle) {
+    let _ = COMPLETION_CHANNELS[handle.index].receiver().try_receive();
+    COMPLETION_POOL.sender().send(handle.index).await;
+}
+
+/// Await completion for the provided handle.
+///
+/// This blocks until the drive loop sends a result (success, failure, or cancel).
+/// Cancellation can come from an interrupt or epoch invalidation.
+pub async fn wait_for_completion(handle: &CompletionHandle) -> DriveCompletion {
+    COMPLETION_CHANNELS[handle.index].receiver().receive().await
+}
+
+/// Get the sender associated with a completion handle.
+///
+/// This is the only value that should be passed across task boundaries; the
+/// `CompletionHandle` stays with the caller and is used to await completion.
+pub fn completion_sender(handle: CompletionHandle) -> types::CompletionSender {
+    COMPLETION_CHANNELS[handle.index].sender()
+}
+
+/// Initialize the completion pool once by seeding available indices.
+fn init_completion_pool_once() {
+    if COMPLETION_POOL_INITIALIZED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
+    {
+        init_completion_pool();
+    }
+}
+
+/// Seed the completion pool with all channel indices.
+fn init_completion_pool() {
+    for (index, _) in COMPLETION_CHANNELS.iter().enumerate() {
+        let _ = COMPLETION_POOL.sender().try_send(index);
+    }
+}
+
+/// Send completion payload if a sender is present.
+///
+/// Guaranteed delivery (awaits), fails only if the receiver was dropped.
+async fn send_completion(completion: Option<types::CompletionSender>, payload: DriveCompletion) {
+    if let Some(sender) = completion {
+        sender.send(payload).await;
+    }
 }
 
 /// Drift compensation state (encoder-based straight-line correction)
@@ -240,12 +329,26 @@ async fn rotation_tick_ms() {
     Timer::after(Duration::from_millis(20)).await;
 }
 
-/// Run a single step of the rotation control loop, if active.
-async fn run_rotation_control_step(rotation_state: &mut Option<RotationState>) {
-    let Some(state) = rotation_state.as_mut() else {
-        return;
-    };
+/// Result of a rotation control step.
+enum RotationStepResult {
+    /// Rotation is still in progress; continue ticking.
+    InProgress,
+    /// Rotation completed successfully with final telemetry.
+    Completed {
+        /// Completion telemetry captured at success.
+        telemetry: CompletionTelemetry,
+    },
+    /// Rotation failed with a static reason and telemetry snapshot.
+    Failed {
+        /// Failure reason identifier.
+        reason: &'static str,
+        /// Completion telemetry captured at failure.
+        telemetry: CompletionTelemetry,
+    },
+}
 
+/// Run a single step of the rotation control loop.
+async fn run_rotation_control_step(rotation_state: &mut RotationState, started_at_ms: u64) -> RotationStepResult {
     // Consume as many queued IMU samples as available; keep the newest one for control.
     let mut latest: Option<ImuMeasurement> = None;
 
@@ -279,29 +382,23 @@ async fn run_rotation_control_step(rotation_state: &mut Option<RotationState>) {
                 sys.right_track_speed = 0;
             }
 
-            // Clear rotation state and notify completion waiters (error will reflect undershoot).
-            let accumulated = state.accumulated_angle.abs();
-            let target = state.target_angle.abs();
+            let accumulated = rotation_state.accumulated_angle.abs();
+            let target = rotation_state.target_angle.abs();
 
-            // Prefer the last known yaw we saw (if any). If the IMU channel has been empty the
-            // entire time, fall back to 0.0 (unknown).
-            let last_yaw_deg = state.last_yaw.unwrap_or(0.0);
+            let last_yaw_deg = rotation_state.last_yaw.unwrap_or(0.0);
+            let duration_ms = Instant::now().as_millis() - started_at_ms;
 
-            let info = RotationCompletedInfo {
-                final_yaw_deg: last_yaw_deg,
-                angle_error_deg: accumulated - target,
+            return RotationStepResult::Failed {
+                reason: "ImuTimeout",
+                telemetry: CompletionTelemetry::RotateExact {
+                    final_yaw_deg: last_yaw_deg,
+                    angle_error_deg: accumulated - target,
+                    duration_ms,
+                },
             };
-
-            if ROTATION_COMPLETED_CHANNEL.sender().try_send(info).is_err() {
-                let _ = ROTATION_COMPLETED_CHANNEL.receiver().try_receive();
-                let _ = ROTATION_COMPLETED_CHANNEL.sender().try_send(info);
-            }
-
-            *rotation_state = None;
-            return;
         }
 
-        return;
+        return RotationStepResult::InProgress;
     };
 
     // Periodic debug (gated): log to confirm IMU flow + accumulation.
@@ -313,14 +410,14 @@ async fn run_rotation_control_step(rotation_state: &mut Option<RotationState>) {
             defmt::info!(
                 "rotate_exact: yaw={=f32}°, acc={=f32}°, target={=f32}°",
                 measurement.orientation.yaw,
-                state.accumulated_angle.abs(),
-                state.target_angle.abs()
+                rotation_state.accumulated_angle.abs(),
+                rotation_state.target_angle.abs()
             );
         }
     }
 
     // Update rotation progress. When done, stop motors and emit completion event + details.
-    let done = state.update(&measurement);
+    let done = rotation_state.update(&measurement);
     if done {
         motor_driver::send_motor_command(MotorCommand::SetTracks {
             left_speed: 0,
@@ -334,32 +431,22 @@ async fn run_rotation_control_step(rotation_state: &mut Option<RotationState>) {
             sys.right_track_speed = 0;
         }
 
-        // Notify system (orchestrator) and any local waiters.
-        raise_event(Events::RotationCompleted).await;
-
         // Provide completion details to anyone awaiting rotation completion.
-        // Normalize error as magnitude-only:
-        // Positive => overshoot, Negative => undershoot (independent of rotation direction).
-        let accumulated = state.accumulated_angle.abs();
-        let target = state.target_angle.abs();
+        let accumulated = rotation_state.accumulated_angle.abs();
+        let target = rotation_state.target_angle.abs();
+        let duration_ms = Instant::now().as_millis() - started_at_ms;
 
-        let info = RotationCompletedInfo {
-            final_yaw_deg: measurement.orientation.yaw,
-            angle_error_deg: accumulated - target,
+        return RotationStepResult::Completed {
+            telemetry: CompletionTelemetry::RotateExact {
+                final_yaw_deg: measurement.orientation.yaw,
+                angle_error_deg: accumulated - target,
+                duration_ms,
+            },
         };
-
-        // Best-effort: if queue is full, drop the oldest completion by receiving one and retrying.
-        if ROTATION_COMPLETED_CHANNEL.sender().try_send(info).is_err() {
-            let _ = ROTATION_COMPLETED_CHANNEL.receiver().try_receive();
-            let _ = ROTATION_COMPLETED_CHANNEL.sender().try_send(info);
-        }
-
-        *rotation_state = None;
-        return;
     }
 
     // Apply updated motor speeds for this step
-    let (left_speed, right_speed) = state.calculate_motor_speeds();
+    let (left_speed, right_speed) = rotation_state.calculate_motor_speeds();
     motor_driver::send_motor_command(MotorCommand::SetTracks {
         left_speed,
         right_speed,
@@ -369,6 +456,8 @@ async fn run_rotation_control_step(rotation_state: &mut Option<RotationState>) {
     let mut sys = SYSTEM_STATE.lock().await;
     sys.left_track_speed = left_speed;
     sys.right_track_speed = right_speed;
+
+    RotationStepResult::InProgress
 }
 
 /// Run a single step of the drift compensation loop
@@ -465,47 +554,90 @@ async fn run_drift_compensation_step(drift: &mut DriftCompensationState, rotatio
     }
 }
 
+/// Active intent being executed by the drive task.
+enum ActiveIntent {
+    /// Active in-place rotation intent with state and optional completion sender.
+    RotateExact {
+        /// Rotation controller state for the in-progress turn.
+        state: RotationState,
+        /// Optional completion sender for the issued command.
+        completion: Option<types::CompletionSender>,
+        /// Start time (ms) used for duration telemetry.
+        started_at_ms: u64,
+    },
+}
+
 /// State for the main drive control loop
 struct DriveLoop {
     /// Whether the system is currently in standby mode (motors disabled)
     standby_enabled: bool,
-    /// Active rotation state, if any (used for closed-loop IMU-based rotation control)
-    rotation_state: Option<RotationState>,
+    /// Active intent, if any
+    active_intent: Option<ActiveIntent>,
     /// State for encoder-based drift compensation (straight-line correction)
     drift: DriftCompensationState,
 }
 
 impl DriveLoop {
-    /// Create a new `DriveLoop` with default state (standby enabled, no active rotation, drift compensation disabled)
+    /// Create a new `DriveLoop` with default state (standby enabled, no active intent, drift compensation disabled)
     const fn new() -> Self {
         Self {
             standby_enabled: true,
-            rotation_state: None,
+            active_intent: None,
             drift: DriftCompensationState::new(),
         }
     }
 
-    /// Handle an incoming drive command by dispatching to the appropriate handler based on command type.
-    async fn handle_command(&mut self, command: DriveCommand) {
-        match command {
+    /// Handle a dequeued command envelope, honoring epoch cancellation.
+    async fn handle_envelope(&mut self, envelope: DriveCommandEnvelope) {
+        let current_epoch = CURRENT_EPOCH.load(Ordering::Relaxed);
+        if envelope.epoch != current_epoch {
+            send_completion(
+                envelope.completion,
+                DriveCompletion {
+                    status: CompletionStatus::Cancelled,
+                    telemetry: CompletionTelemetry::None,
+                },
+            )
+            .await;
+            return;
+        }
+
+        let completion = envelope.completion;
+        match envelope.command {
             DriveCommand::Drive(action) => {
-                self.handle_drive_action(action).await;
+                self.handle_drive_action(action, completion).await;
             }
             DriveCommand::RunMotorCalibration => {
                 info!("Starting motor calibration procedure");
                 run_motor_calibration().await;
                 info!("Motor calibration procedure completed");
+                send_completion(
+                    completion,
+                    DriveCompletion {
+                        status: CompletionStatus::Success,
+                        telemetry: CompletionTelemetry::None,
+                    },
+                )
+                .await;
             }
             DriveCommand::RunImuCalibration(kind) => {
                 info!("Starting IMU calibration procedure");
                 run_imu_calibration(kind).await;
                 info!("IMU calibration procedure completed");
+                send_completion(
+                    completion,
+                    DriveCompletion {
+                        status: CompletionStatus::Success,
+                        telemetry: CompletionTelemetry::None,
+                    },
+                )
+                .await;
             }
         }
     }
 
     /// Handle a `DriveAction` command by executing the corresponding motor commands and state updates.
-    async fn handle_drive_action(&mut self, action: DriveAction) {
+    async fn handle_drive_action(&mut self, action: DriveAction, completion: Option<types::CompletionSender>) {
         // Wake from standby if movement requested
         if self.standby_enabled {
             match &action {
@@ -518,30 +650,57 @@ impl DriveLoop {
             }
         }
 
-        // Clear rotation state unless this is a rotation command
-        if !matches!(&action, DriveAction::RotateExact { .. }) {
-            // self.rotation_state = None;
-        }
-
         match action {
             DriveAction::SetSpeed { left, right } => {
                 self.handle_set_speed(left, right).await;
+                send_completion(
+                    completion,
+                    DriveCompletion {
+                        status: CompletionStatus::Success,
+                        telemetry: CompletionTelemetry::None,
+                    },
+                )
+                .await;
             }
             DriveAction::RotateExact {
                 degrees,
                 direction,
                 motion,
             } => {
-                self.handle_rotate_exact(degrees, direction, motion).await;
+                self.handle_rotate_exact(degrees, direction, motion, completion).await;
             }
             DriveAction::Coast => {
                 self.handle_coast().await;
+                send_completion(
+                    completion,
+                    DriveCompletion {
+                        status: CompletionStatus::Success,
+                        telemetry: CompletionTelemetry::None,
+                    },
+                )
+                .await;
             }
             DriveAction::Brake => {
                 self.handle_brake().await;
+                send_completion(
+                    completion,
+                    DriveCompletion {
+                        status: CompletionStatus::Success,
+                        telemetry: CompletionTelemetry::None,
+                    },
+                )
+                .await;
             }
             DriveAction::Standby => {
                 self.handle_standby().await;
+                send_completion(
+                    completion,
+                    DriveCompletion {
+                        status: CompletionStatus::Success,
+                        telemetry: CompletionTelemetry::None,
+                    },
+                )
+                .await;
             }
         }
     }
@@ -595,26 +754,34 @@ impl DriveLoop {
         degrees: f32,
         direction: types::RotationDirection,
         motion: types::RotationMotion,
+        completion: Option<types::CompletionSender>,
     ) {
         // Request IMU start for closed-loop rotation control.
         // The orchestrator handles this event and starts IMU streaming.
         raise_event(Events::StartStopMotionDataCollection(true)).await;
 
-        // Initialize new rotation state
-        self.rotation_state = Some(RotationState::new(degrees, direction, motion));
+        let rotation_state = RotationState::new(degrees, direction, motion);
+        let started_at_ms = Instant::now().as_millis();
+
         // Apply initial motor speeds for rotation
-        if let Some(rotation_state) = self.rotation_state.as_ref() {
-            let (left_speed, right_speed) = rotation_state.calculate_motor_speeds();
-            motor_driver::send_motor_command(MotorCommand::SetTracks {
-                left_speed,
-                right_speed,
-            })
-            .await;
-            // Update system state
-            let mut state = SYSTEM_STATE.lock().await;
-            state.left_track_speed = left_speed;
-            state.right_track_speed = right_speed;
-        }
+        let (left_speed, right_speed) = rotation_state.calculate_motor_speeds();
+        motor_driver::send_motor_command(MotorCommand::SetTracks {
+            left_speed,
+            right_speed,
+        })
+        .await;
+
+        // Update system state
+        let mut state = SYSTEM_STATE.lock().await;
+        state.left_track_speed = left_speed;
+        state.right_track_speed = right_speed;
+        drop(state);
+
+        self.active_intent = Some(ActiveIntent::RotateExact {
+            state: rotation_state,
+            completion,
+            started_at_ms,
+        });
     }
 
     /// Handle a `Coast` command by disabling compensation, stopping encoder sampling, and sending coast command.
@@ -669,6 +836,58 @@ impl DriveLoop {
             state.right_track_speed = 0;
         }
     }
+
+    /// Handle an interrupt by applying motor action, cancelling the active intent only,
+    /// and bumping the epoch to invalidate queued commands.
+    /// Only the active intent’s completion is resolved here; queued commands are cancelled
+    /// when dequeued due to epoch mismatch.
+    async fn handle_interrupt(&mut self, kind: InterruptKind) {
+        match kind {
+            InterruptKind::EmergencyBrake => {
+                motor_driver::send_motor_command(MotorCommand::BrakeAll).await;
+            }
+            InterruptKind::Stop | InterruptKind::CancelCurrent => {
+                motor_driver::send_motor_command(MotorCommand::CoastAll).await;
+            }
+        }
+
+        // Disable compensation and stop encoder sampling
+        self.drift.enabled = false;
+        encoder_read::send_command(encoder_read::EncoderCommand::Stop).await;
+
+        // Cancel active intent
+        if let Some(intent) = self.active_intent.take() {
+            let ActiveIntent::RotateExact {
+                state,
+                completion,
+                started_at_ms,
+            } = intent;
+            let accumulated = state.accumulated_angle.abs();
+            let target = state.target_angle.abs();
+            let last_yaw_deg = state.last_yaw.unwrap_or(0.0);
+            let duration_ms = Instant::now().as_millis() - started_at_ms;
+
+            send_completion(
+                completion,
+                DriveCompletion {
+                    status: CompletionStatus::Cancelled,
+                    telemetry: CompletionTelemetry::RotateExact {
+                        final_yaw_deg: last_yaw_deg,
+                        angle_error_deg: accumulated - target,
+                        duration_ms,
+                    },
+                },
+            )
+            .await;
+        }
+
+        // Invalidate queued commands
+        CURRENT_EPOCH.fetch_add(1, Ordering::Relaxed);
+
+        let mut state = SYSTEM_STATE.lock().await;
+        state.left_track_speed = 0;
+        state.right_track_speed = 0;
+    }
 }
 
 /// Drive control task - coordinates motion and sensor feedback
@@ -676,9 +895,10 @@ impl DriveLoop {
 /// # Architecture
 ///
 /// This is a high-level control task that:
-/// - Receives drive commands via signal
+/// - Receives drive commands via queue
 /// - Receives encoder feedback via channel (from orchestrator)
 /// - Receives IMU feedback via command (from orchestrator)
+/// - Receives interrupts via signal
 /// - Sends motor commands to `motor_driver` task
 /// - Coordinates calibration procedures
 ///
@@ -691,21 +911,74 @@ impl DriveLoop {
 #[embassy_executor::task]
 pub async fn drive() {
     let mut loop_state = DriveLoop::new();
+    init_completion_pool_once();
 
     loop {
-        // Prioritize drive commands; otherwise tick rotation control at 30Hz; otherwise run drift tick.
-        let command_or_rotation_tick = select(wait(), rotation_tick_ms()).await;
-
-        match command_or_rotation_tick {
-            Either::First(command) => {
-                loop_state.handle_command(command).await;
+        if let Some(intent) = loop_state.active_intent.as_mut() {
+            match intent {
+                ActiveIntent::RotateExact {
+                    state,
+                    completion,
+                    started_at_ms,
+                } => {
+                    let interrupt_or_tick = select(DRIVE_INTERRUPT.wait(), rotation_tick_ms()).await;
+                    match interrupt_or_tick {
+                        Either::First(kind) => {
+                            loop_state.handle_interrupt(kind).await;
+                        }
+                        Either::Second(()) => match run_rotation_control_step(state, *started_at_ms).await {
+                            RotationStepResult::InProgress => {}
+                            RotationStepResult::Completed { telemetry } => {
+                                let completion = completion.take();
+                                send_completion(
+                                    completion,
+                                    DriveCompletion {
+                                        status: CompletionStatus::Success,
+                                        telemetry,
+                                    },
+                                )
+                                .await;
+                                loop_state.active_intent = None;
+                            }
+                            RotationStepResult::Failed { reason, telemetry } => {
+                                let completion = completion.take();
+                                send_completion(
+                                    completion,
+                                    DriveCompletion {
+                                        status: CompletionStatus::Failed(reason),
+                                        telemetry,
+                                    },
+                                )
+                                .await;
+                                loop_state.active_intent = None;
+                            }
+                        },
+                    }
+                }
             }
-            Either::Second(()) => {
-                run_rotation_control_step(&mut loop_state.rotation_state).await;
+            continue;
+        }
 
-                // Drift compensation runs only when enabled and not rotating; keep its own cadence.
-                drift_tick_ms().await;
-                run_drift_compensation_step(&mut loop_state.drift, loop_state.rotation_state.as_ref()).await;
+        if loop_state.drift.enabled {
+            let event_or_tick = select(
+                select(DRIVE_QUEUE.receiver().receive(), DRIVE_INTERRUPT.wait()),
+                drift_tick_ms(),
+            )
+            .await;
+            match event_or_tick {
+                Either::First(inner) => match inner {
+                    Either::First(envelope) => loop_state.handle_envelope(envelope).await,
+                    Either::Second(kind) => loop_state.handle_interrupt(kind).await,
+                },
+                Either::Second(()) => {
+                    run_drift_compensation_step(&mut loop_state.drift, None).await;
+                }
+            }
+        } else {
+            let command_or_interrupt = select(DRIVE_QUEUE.receiver().receive(), DRIVE_INTERRUPT.wait()).await;
+            match command_or_interrupt {
+                Either::First(envelope) => loop_state.handle_envelope(envelope).await,
+                Either::Second(kind) => loop_state.handle_interrupt(kind).await,
             }
         }
     }

--- a/src/task/drive/mod.rs
+++ b/src/task/drive/mod.rs
@@ -867,6 +867,7 @@ impl DriveLoop {
             let last_yaw_deg = state.last_yaw.unwrap_or(0.0);
             let duration_ms = Instant::now().as_millis() - started_at_ms;
 
+            raise_event(Events::StartStopMotionDataCollection(false)).await;
             send_completion(
                 completion,
                 DriveCompletion {
@@ -930,6 +931,7 @@ pub async fn drive() {
                             RotationStepResult::InProgress => {}
                             RotationStepResult::Completed { telemetry } => {
                                 let completion = completion.take();
+                                raise_event(Events::StartStopMotionDataCollection(false)).await;
                                 send_completion(
                                     completion,
                                     DriveCompletion {
@@ -942,6 +944,7 @@ pub async fn drive() {
                             }
                             RotationStepResult::Failed { reason, telemetry } => {
                                 let completion = completion.take();
+                                raise_event(Events::StartStopMotionDataCollection(false)).await;
                                 send_completion(
                                     completion,
                                     DriveCompletion {

--- a/src/task/drive/types.rs
+++ b/src/task/drive/types.rs
@@ -1,5 +1,10 @@
 //! Type definitions and constants for drive control
 
+use embassy_sync::{
+    blocking_mutex::raw::CriticalSectionRawMutex,
+    channel::{Receiver, Sender},
+};
+
 /// Drift compensation sample interval in milliseconds
 pub const DRIFT_COMPENSATION_INTERVAL_MS: u64 = 200;
 
@@ -69,6 +74,69 @@ pub enum DriveAction {
         motion: RotationMotion,
     },
 }
+
+/// Interrupt commands that preempt active drive intents.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum InterruptKind {
+    /// Immediately brake all motors.
+    EmergencyBrake,
+    /// Stop motors without braking.
+    Stop,
+    /// Cancel the active intent without issuing a stop/brake.
+    CancelCurrent,
+}
+
+/// Completion status for long-running commands.
+///
+/// Used by per-command completion handles to report final outcomes.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum CompletionStatus {
+    /// Command finished successfully.
+    Success,
+    /// Command was cancelled by an interrupt or newer epoch.
+    Cancelled,
+    /// Command failed with a reason string.
+    Failed(&'static str),
+}
+
+/// Completion telemetry for long-running commands.
+///
+/// Used by per-command completion handles to return command-specific details.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CompletionTelemetry {
+    /// No telemetry payload.
+    None,
+    /// Telemetry for `RotateExact`.
+    RotateExact {
+        /// IMU yaw at completion (degrees).
+        final_yaw_deg: f32,
+        /// Signed error (degrees): achieved - target.
+        angle_error_deg: f32,
+        /// Duration in milliseconds.
+        duration_ms: u64,
+    },
+}
+
+/// Generic completion payload for drive commands.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DriveCompletion {
+    /// Overall status.
+    pub status: CompletionStatus,
+    /// Command-specific telemetry.
+    pub telemetry: CompletionTelemetry,
+}
+
+/// One-shot completion sender type.
+///
+/// Obtain via a completion handle from the pool; do not construct channels manually.
+/// Pass this to `send_drive_command_with_completion`.
+pub type CompletionSender = Sender<'static, CriticalSectionRawMutex, DriveCompletion, 1>;
+
+/// One-shot completion receiver type.
+///
+/// Managed by the completion handle pool; do not construct manually.
+/// Callers should await via `wait_for_completion`.
+pub type CompletionReceiver = Receiver<'static, CriticalSectionRawMutex, DriveCompletion, 1>;
 
 /// Rotation direction for precise turning
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/src/task/initialization/mod.rs
+++ b/src/task/initialization/mod.rs
@@ -8,7 +8,7 @@ use defmt::info;
 use heapless::String;
 
 use crate::{
-    system::state::{self, CalibrationStatus, SYSTEM_STATE},
+    system::state::{CalibrationStatus, SYSTEM_STATE},
     task::{
         io::{display, flash_storage},
         motor_driver,

--- a/src/task/io/port_expander.rs
+++ b/src/task/io/port_expander.rs
@@ -61,8 +61,8 @@ use crate::{
 /// PCA9555 I2C address (A0=high, A1=A2=low -> 0x21)
 const PCA9555_ADDR: u8 = 0x21;
 
-/// Input register for Port 0.
-const REG_INPUT_PORT0: u8 = 0x00;
+// Input register for Port 0. Not used ATM
+// const REG_INPUT_PORT0: u8 = 0x00;
 /// Input register for Port 1.
 const REG_INPUT_PORT1: u8 = 0x01;
 /// Output register for Port 0.
@@ -75,10 +75,10 @@ const REG_CONFIG_PORT0: u8 = 0x06;
 const REG_CONFIG_PORT1: u8 = 0x07;
 
 /// Command channel for port expander operations
-static COMMAND_CHANNEL: Channel<CriticalSectionRawMutex, PortExpanderCommand, 16> = Channel::new();
+static COMMAND_CHANNEL: Channel<CriticalSectionRawMutex, PortExpanderOutputCommand, 16> = Channel::new();
 
 /// Send a command to the port expander task
-pub async fn send_command(command: PortExpanderCommand) {
+pub async fn send_command(command: PortExpanderOutputCommand) {
     COMMAND_CHANNEL.sender().send(command).await;
 }
 
@@ -93,9 +93,9 @@ pub enum PortNumber {
 
 /// Generic port expander commands - no motor-specific knowledge
 #[derive(Debug, Clone, Copy, Format)]
-pub enum PortExpanderCommand {
+pub enum PortExpanderOutputCommand {
     /// Set a single output pin state
-    OutputPin {
+    Pin {
         /// Target port.
         port: PortNumber,
         /// Pin index (0-7).
@@ -105,7 +105,7 @@ pub enum PortExpanderCommand {
     },
 
     /// Set entire port output byte at once
-    OutputByte {
+    Byte {
         /// Target port.
         port: PortNumber,
         /// Output value for all 8 pins.
@@ -114,7 +114,7 @@ pub enum PortExpanderCommand {
 
     /// Set multiple bits using mask (efficient for updating specific bits)
     /// Only bits where mask=1 are affected
-    OutputBits {
+    Bits {
         /// Target port.
         port: PortNumber,
         /// Bitmask of pins to update.
@@ -122,14 +122,13 @@ pub enum PortExpanderCommand {
         /// Values for masked pins.
         value: u8,
     },
-
-    /// Set both ports at once (atomic, most efficient)
-    BothPorts {
-        /// Output value for port 0.
-        port0: u8,
-        /// Output value for port 1.
-        port1: u8,
-    },
+    // Set both ports at once (atomic, most efficient)
+    // BothPorts {
+    //     /// Output value for port 0.
+    //     port0: u8,
+    //     /// Output value for port 1.
+    //     port1: u8,
+    // },
 }
 
 /// Input state tracking for Port 1
@@ -402,10 +401,10 @@ pub async fn port_expander(i2c_bus: &'static I2cBusShared, mut interrupt: Input<
 async fn process_command(
     state: &mut PortExpanderState,
     driver: &Pca9555Driver,
-    command: PortExpanderCommand,
+    command: PortExpanderOutputCommand,
 ) -> Result<(), ()> {
     match command {
-        PortExpanderCommand::OutputPin {
+        PortExpanderOutputCommand::Pin {
             port,
             pin,
             state: pin_state,
@@ -413,17 +412,16 @@ async fn process_command(
             state.set_output_pin(port, pin, pin_state);
         }
 
-        PortExpanderCommand::OutputByte { port, value } => {
+        PortExpanderOutputCommand::Byte { port, value } => {
             state.set_output_byte(port, value);
         }
 
-        PortExpanderCommand::OutputBits { port, mask, value } => {
+        PortExpanderOutputCommand::Bits { port, mask, value } => {
             state.set_output_bits(port, mask, value);
-        }
-
-        PortExpanderCommand::BothPorts { port0, port1 } => {
-            state.set_both_ports(port0, port1);
-        }
+        } // not currently used
+          // PortExpanderCommand::BothPorts { port0, port1 } => {
+          //     state.set_both_ports(port0, port1);
+          // }
     }
 
     // Write the updated state to hardware

--- a/src/task/motor_driver.rs
+++ b/src/task/motor_driver.rs
@@ -97,7 +97,7 @@ use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Channe
 
 use crate::{
     system::state,
-    task::io::port_expander::{self, PortExpanderCommand, PortNumber},
+    task::io::port_expander::{self},
 };
 
 /// Target motor voltage (we compensate battery voltage down to this)
@@ -176,7 +176,7 @@ pub enum MotorDirection {
 /// These functions prepare generic port expander commands for motor control
 mod motor_port_mapping {
     use crate::task::{
-        io::port_expander::{PortExpanderCommand, PortNumber},
+        io::port_expander::{PortExpanderOutputCommand, PortNumber},
         motor_driver::{Motor, MotorDirection, Track},
     };
 
@@ -202,7 +202,11 @@ mod motor_port_mapping {
     }
 
     /// Create port expander command to set a motor's direction
-    pub const fn set_motor_direction_cmd(track: Track, motor: Motor, direction: MotorDirection) -> PortExpanderCommand {
+    pub const fn set_motor_direction_cmd(
+        track: Track,
+        motor: Motor,
+        direction: MotorDirection,
+    ) -> PortExpanderOutputCommand {
         let (fwd_bit, bwd_bit) = get_motor_direction_bits(track, motor);
 
         let (fwd_state, bwd_state) = match direction {
@@ -216,7 +220,7 @@ mod motor_port_mapping {
         let mask = (1 << fwd_bit) | (1 << bwd_bit);
         let value = ((fwd_state as u8) << fwd_bit) | ((bwd_state as u8) << bwd_bit);
 
-        PortExpanderCommand::OutputBits {
+        PortExpanderOutputCommand::Bits {
             port: PortNumber::Port0,
             mask,
             value,
@@ -229,7 +233,7 @@ mod motor_port_mapping {
         left_rear: MotorDirection,
         right_front: MotorDirection,
         right_rear: MotorDirection,
-    ) -> PortExpanderCommand {
+    ) -> PortExpanderOutputCommand {
         let mut port0_value = 0u8;
 
         // Helper to set direction bits
@@ -254,17 +258,17 @@ mod motor_port_mapping {
         set_direction(&mut port0_value, Track::Right, Motor::Front, right_front);
         set_direction(&mut port0_value, Track::Right, Motor::Rear, right_rear);
 
-        PortExpanderCommand::OutputByte {
+        PortExpanderOutputCommand::Byte {
             port: PortNumber::Port0,
             value: port0_value,
         }
     }
 
     /// Create port expander command to enable/disable a motor driver
-    pub const fn set_driver_enable_cmd(track: Track, enabled: bool) -> PortExpanderCommand {
+    pub const fn set_driver_enable_cmd(track: Track, enabled: bool) -> PortExpanderOutputCommand {
         let bit = get_driver_enable_bit(track);
 
-        PortExpanderCommand::OutputPin {
+        PortExpanderOutputCommand::Pin {
             port: PortNumber::Port1,
             pin: bit,
             state: enabled,
@@ -272,11 +276,11 @@ mod motor_port_mapping {
     }
 
     /// Create port expander command to enable/disable both drivers at once
-    pub const fn set_all_drivers_enable_cmd(enabled: bool) -> PortExpanderCommand {
+    pub const fn set_all_drivers_enable_cmd(enabled: bool) -> PortExpanderOutputCommand {
         let mask = (1 << 4) | (1 << 5); // Bits 4 and 5 (left and right drivers)
         let value = if enabled { mask } else { 0 };
 
-        PortExpanderCommand::OutputBits {
+        PortExpanderOutputCommand::Bits {
             port: PortNumber::Port1,
             mask,
             value,

--- a/src/task/orchestrate.rs
+++ b/src/task/orchestrate.rs
@@ -53,9 +53,9 @@ async fn handle_event(event: Events) {
             behavior::sensor_events::handle_ultrasonic_sweep_reading(distance, angle).await;
         }
         Events::ImuMeasurementTaken(measurement) => {
-            behavior::sensor_events::handle_imu_measurement(measurement).await;
+            behavior::sensor_events::handle_imu_measurement(measurement);
         }
-        Events::RotationCompleted => behavior::motion::handle_rotation_completed().await,
+
         Events::StartStopMotionDataCollection(start) => behavior::motion::handle_start_stop_motion_data(start),
         Events::StartStopUltrasonicSweep(start) => behavior::motion::handle_start_stop_ultrasonic_sweep(start).await,
         Events::CalibrationStatus {

--- a/src/task/sensors/encoders.rs
+++ b/src/task/sensors/encoders.rs
@@ -193,7 +193,7 @@ pub async fn encoder_read(
 ) {
     info!("Encoder read task started");
 
-    let mut encoders = EncoderChannels {
+    let encoders = EncoderChannels {
         left_front: encoder_left_front,
         left_rear: encoder_left_rear,
         right_front: encoder_right_front,

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -48,8 +48,6 @@
 //! sensors::imu::stop_imu_readings();
 //! ```
 
-use core::f32::consts::PI;
-
 use ahrs::{Ahrs, Madgwick};
 use defmt::{info, warn};
 use embassy_embedded_hal::shared_bus::asynch::i2c::I2cDevice;
@@ -338,7 +336,7 @@ async fn init_imu_sensor(i2c_bus: &'static I2cBusShared) -> ImuSensor {
 
     // Initialize ICM20948 with retries
     let mut attempt: u32 = 0;
-    let mut sensor = loop {
+    let sensor = loop {
         attempt += 1;
 
         info!(
@@ -450,7 +448,7 @@ async fn configure_imu_sensor(sensor: &mut ImuSensor) -> bool {
 
 /// Initialize the Madgwick AHRS filter
 fn init_madgwick() -> Madgwick<f32> {
-    let mut madgwick = Madgwick::new(1.0 / SAMPLE_RATE_HZ, BETA);
+    let madgwick = Madgwick::new(1.0 / SAMPLE_RATE_HZ, BETA);
 
     info!("Madgwick AHRS filter initialized:");
     info!("  Sample rate: {} Hz", SAMPLE_RATE_HZ);

--- a/src/task/testmode/testing.rs
+++ b/src/task/testmode/testing.rs
@@ -30,7 +30,11 @@ use heapless::String;
 use crate::{
     system::event::{Events, raise_event},
     task::{
-        drive::{DriveAction, DriveCommand, ImuCalibrationKind, send_drive_command},
+        drive::{
+            CompletionStatus, CompletionTelemetry, DriveAction, DriveCommand, ImuCalibrationKind,
+            acquire_completion_handle, completion_sender, release_completion_handle, send_drive_command,
+            send_drive_command_with_completion, wait_for_completion,
+        },
         io::display::{DisplayAction, display_update},
         sensors::imu::{AhrsFusionMode, set_ahrs_fusion_mode},
     },
@@ -62,6 +66,7 @@ async fn testing_sequence_runner() {
 /// Main testing sequence.
 ///
 /// This is the entry point for all development tests. Modify as needed.
+#[allow(clippy::too_many_lines)]
 async fn run_testing_sequence() {
     async fn show_line(line: u8, msg: &str) {
         let mut s: String<20> = String::new();
@@ -141,40 +146,67 @@ async fn run_testing_sequence() {
         show_line(3, "").await;
 
         // Ensure we're stopped before the next turn
-        send_drive_command(DriveCommand::Drive(DriveAction::SetSpeed { left: 0, right: 0 }));
+        send_drive_command(DriveCommand::Drive(DriveAction::SetSpeed { left: 0, right: 0 })).await;
         Timer::after(Duration::from_millis(500)).await;
 
+        let Ok(mut completion_handle) = acquire_completion_handle().await else {
+            defmt::warn!("🧪 TEST: completion pool exhausted; skipping turn");
+            continue;
+        };
+        let sender = completion_sender(completion_handle);
+
         // Start the turn
-        send_drive_command(DriveCommand::Drive(DriveAction::RotateExact {
-            degrees: target_deg,
-            direction: crate::task::drive::types::RotationDirection::Clockwise,
-            motion: crate::task::drive::types::RotationMotion::Stationary { speed },
-        }));
-
-        // Await completion (no global event consumption)
-        let completion = crate::task::drive::wait_for_rotation_completed().await;
-
-        // The controller reports normalized error:
-        // error = achieved - target, so achieved = target + error.
-        let achieved_deg = target_deg + completion.angle_error_deg;
-
-        // Update display with the final telemetry for this turn.
-        show_turn_status(
-            target_deg,
-            achieved_deg,
-            completion.final_yaw_deg,
-            completion.angle_error_deg,
+        send_drive_command_with_completion(
+            DriveCommand::Drive(DriveAction::RotateExact {
+                degrees: target_deg,
+                direction: crate::task::drive::types::RotationDirection::Clockwise,
+                motion: crate::task::drive::types::RotationMotion::Stationary { speed },
+            }),
+            sender,
         )
         .await;
 
+        // Await completion (no global event consumption)
+        let completion = wait_for_completion(&completion_handle).await;
+        release_completion_handle(completion_handle).await;
+
+        let (final_yaw_deg, angle_error_deg, status) = if let CompletionTelemetry::RotateExact {
+            final_yaw_deg,
+            angle_error_deg,
+            ..
+        } = completion.telemetry
+        {
+            (final_yaw_deg, angle_error_deg, completion.status)
+        } else {
+            defmt::warn!("🧪 TEST: Unexpected completion telemetry");
+            (0.0, 0.0, completion.status)
+        };
+
+        // The controller reports normalized error:
+        // error = achieved - target, so achieved = target + error.
+        let achieved_deg = target_deg + angle_error_deg;
+
+        // Update display with the final telemetry for this turn.
+        show_turn_status(target_deg, achieved_deg, final_yaw_deg, angle_error_deg).await;
+
+        let status_str = match status {
+            CompletionStatus::Success => "Success",
+            CompletionStatus::Cancelled => "Cancelled",
+            CompletionStatus::Failed(_) => "Failed",
+        };
         defmt::info!(
-            "🧪 TEST: Rotation complete: final_yaw={=f32}°, angle_error={=f32}°",
-            completion.final_yaw_deg,
-            completion.angle_error_deg
+            "🧪 TEST: Rotation complete: status={=str}, final_yaw={=f32}°, angle_error={=f32}°",
+            status_str,
+            final_yaw_deg,
+            angle_error_deg
         );
 
+        if let CompletionStatus::Failed(reason) = status {
+            defmt::warn!("🧪 TEST: Rotation failed: {=str}", reason);
+        }
+
         // Stop after each turn
-        send_drive_command(DriveCommand::Drive(DriveAction::Coast));
+        send_drive_command(DriveCommand::Drive(DriveAction::Coast)).await;
         Timer::after(Duration::from_millis(750)).await;
     }
 
@@ -190,7 +222,6 @@ async fn run_testing_sequence() {
 /// operational speeds.
 ///
 /// Uncomment and use this if you need to run full calibration during development.
-#[allow(dead_code)]
 #[embassy_executor::task]
 async fn auto_calibration_sequence() {
     // Send initialization event
@@ -204,7 +235,7 @@ async fn auto_calibration_sequence() {
     Timer::after(Duration::from_secs(2)).await;
 
     defmt::info!("🤖 AUTO-CALIBRATION: Triggering motor calibration now!");
-    send_drive_command(DriveCommand::RunMotorCalibration);
+    send_drive_command(DriveCommand::RunMotorCalibration).await;
 
     // Wait for motor calibration to complete (~50s) plus delay
     Timer::after(Duration::from_secs(80)).await;
@@ -213,5 +244,5 @@ async fn auto_calibration_sequence() {
     Timer::after(Duration::from_secs(10)).await;
 
     defmt::info!("🤖 AUTO-CALIBRATION: Triggering IMU calibration now!");
-    send_drive_command(DriveCommand::RunImuCalibration(ImuCalibrationKind::Full));
+    send_drive_command(DriveCommand::RunImuCalibration(ImuCalibrationKind::Full)).await;
 }

--- a/src/task/ui/mod.rs
+++ b/src/task/ui/mod.rs
@@ -123,16 +123,19 @@ pub async fn handle_rotary_button_pressed() {
 
             match selection {
                 CalibrationSelection::Motor => {
-                    drive::send_drive_command(drive::DriveCommand::RunMotorCalibration);
+                    drive::send_drive_command(drive::DriveCommand::RunMotorCalibration).await;
                 }
                 CalibrationSelection::Mag => {
-                    drive::send_drive_command(drive::DriveCommand::RunImuCalibration(drive::ImuCalibrationKind::Mag));
+                    drive::send_drive_command(drive::DriveCommand::RunImuCalibration(drive::ImuCalibrationKind::Mag))
+                        .await;
                 }
                 CalibrationSelection::Accel => {
-                    drive::send_drive_command(drive::DriveCommand::RunImuCalibration(drive::ImuCalibrationKind::Accel));
+                    drive::send_drive_command(drive::DriveCommand::RunImuCalibration(drive::ImuCalibrationKind::Accel))
+                        .await;
                 }
                 CalibrationSelection::Gyro => {
-                    drive::send_drive_command(drive::DriveCommand::RunImuCalibration(drive::ImuCalibrationKind::Gyro));
+                    drive::send_drive_command(drive::DriveCommand::RunImuCalibration(drive::ImuCalibrationKind::Gyro))
+                        .await;
                 }
             }
         }

--- a/src/task/ui/render.rs
+++ b/src/task/ui/render.rs
@@ -2,8 +2,6 @@
 //!
 //! Renders UI screens based on the current UI state and system data.
 
-use core::fmt::Write;
-
 use heapless::String;
 
 use super::{screens, state::UiState};

--- a/src/task/ui/screens.rs
+++ b/src/task/ui/screens.rs
@@ -3,7 +3,7 @@
 //! This module provides small, reusable helpers to render UI screens
 //! and system info on the OLED via the display task.
 
-use core::{fmt::Write, ops::Add};
+use core::fmt::Write;
 
 use heapless::{String, Vec};
 


### PR DESCRIPTION
completion. For now this only really is required for exact Rotation but eventuall will at least be useful for dedicated distance driving. Select over a drive command and a drive interrupt to allow emergecy commands like stopping dead. Drive Commands can be enqueued. Completion telemetry for now only has implementation for rotation completion data, more can be added later.