### PR TITLE
Rework imu calibration

### DIFF
--- a/src/system/state.rs
+++ b/src/system/state.rs
@@ -55,6 +55,8 @@ pub enum TestSelection {
     Combined,
     /// IMU live display test
     Imu,
+    /// IMU live display test (6-axis)
+    Imu6,
     /// Basic motor test
     BasicMotor,
     /// IR + ultrasonic live display test

--- a/src/task/drive/calibration/imu.rs
+++ b/src/task/drive/calibration/imu.rs
@@ -44,6 +44,7 @@ struct MagCalibrationConfig {
     /// Max allowed delta from baseline magnitude (μT).
     verify_max_delta_ut: f32,
     /// Status update cadence (seconds).
+    #[allow(dead_code)]
     status_interval_secs: u64,
 }
 
@@ -59,6 +60,10 @@ const MAG_CALIBRATION_CONFIG: MagCalibrationConfig = MagCalibrationConfig {
     verify_max_delta_ut: 20.0,
     status_interval_secs: 2,
 };
+
+/// Maximum time to wait for a fresh gyro/accel sample during calibration.
+/// Must be comfortably above the IMU sampling period (~20.4 ms at 48.9 Hz).
+const GYRO_ACCEL_SAMPLE_TIMEOUT: Duration = Duration::from_millis(30);
 
 #[derive(Copy, Clone)]
 /// Motor command step used to measure or verify mag interference.
@@ -182,6 +187,104 @@ impl MagCoverage {
     }
 }
 
+/// Rotation guidance step for magnetometer coverage.
+struct MagRotationStep {
+    /// Label to show on the OLED for this step.
+    label: &'static str,
+    /// Require X-axis coverage for this step.
+    require_x: bool,
+    /// Require Y-axis coverage for this step.
+    require_y: bool,
+    /// Require Z-axis coverage for this step.
+    require_z: bool,
+    /// Minimum yaw heading span in degrees for this step (None = not used).
+    min_heading_span_deg: Option<f32>,
+}
+
+/// Magnetometer calibration phase machine.
+#[derive(Copy, Clone, Eq, PartialEq)]
+#[allow(dead_code)]
+enum MagCalibrationPhase {
+    /// Manual yaw rotation phase.
+    ManualYaw,
+    /// Manual pitch rotation phase.
+    ManualPitch,
+    /// Manual roll rotation phase.
+    ManualRoll,
+    /// Settling delay before motor phase.
+    SettleDelay,
+    /// Baseline magnetometer measurement with motors off.
+    MotorBaseline,
+    /// Motor interference measurement phase.
+    MotorMeasure,
+    /// Motor interference verification phase.
+    MotorVerify,
+    /// Save calibration results.
+    Save,
+    /// Completed calibration flow.
+    Done,
+    /// Calibration failed.
+    Failed,
+}
+
+impl MagCalibrationPhase {
+    /// Human-readable phase name.
+    const fn label(self) -> &'static str {
+        match self {
+            Self::ManualYaw => "P1 YAW",
+            Self::ManualPitch => "P2 PITCH",
+            Self::ManualRoll => "P3 ROLL",
+            Self::SettleDelay => "P4 WAIT20",
+            Self::MotorBaseline => "P5 BASE",
+            Self::MotorMeasure => "P6 MOTOR",
+            Self::MotorVerify => "P7 VERIFY",
+            Self::Save => "P8 SAVE",
+            Self::Done => "DONE",
+            Self::Failed => "FAIL",
+        }
+    }
+
+    /// 1-based phase number and total count for user-visible progress.
+    const fn progress(self) -> Option<(u8, u8)> {
+        match self {
+            Self::ManualYaw => Some((1, 8)),
+            Self::ManualPitch => Some((2, 8)),
+            Self::ManualRoll => Some((3, 8)),
+            Self::SettleDelay => Some((4, 8)),
+            Self::MotorBaseline => Some((5, 8)),
+            Self::MotorMeasure => Some((6, 8)),
+            Self::MotorVerify => Some((7, 8)),
+            Self::Save => Some((8, 8)),
+            Self::Done | Self::Failed => None,
+        }
+    }
+}
+
+/// Sequence of user-guided rotations for magnetometer coverage.
+const MAG_ROTATION_STEPS: [MagRotationStep; 3] = [
+    MagRotationStep {
+        label: "Yaw flat",
+        require_x: false,
+        require_y: false,
+        require_z: false,
+        min_heading_span_deg: Some(50.0),
+    },
+    MagRotationStep {
+        label: "Pitch",
+        require_x: true,
+        require_y: false,
+        require_z: true,
+        min_heading_span_deg: None,
+    },
+    MagRotationStep {
+        label: "Roll",
+        require_x: false,
+        require_y: true,
+        require_z: true,
+        min_heading_span_deg: None,
+    },
+];
+
 /// Captured motor interference vectors at 50% and 100% commands.
 struct InterferenceData {
     /// X-axis interference at 50% (all, left, right).
@@ -286,8 +389,8 @@ async fn run_gyro_accel_calibration(run_gyro: bool, run_accel: bool) -> GyroAcce
     for i in 0..num_samples {
         if run_gyro {
             clear_gyro_measurement().await;
-            let start = embassy_time::Instant::now();
-            while embassy_time::Instant::now().duration_since(start).as_millis() < 20 {
+            let deadline = embassy_time::Instant::now() + GYRO_ACCEL_SAMPLE_TIMEOUT;
+            while embassy_time::Instant::now() < deadline {
                 if let Some(gyro_data) = get_latest_gyro_measurement().await {
                     gyro_sum += gyro_data;
                     gyro_samples += 1;
@@ -299,8 +402,8 @@ async fn run_gyro_accel_calibration(run_gyro: bool, run_accel: bool) -> GyroAcce
 
         if run_accel {
             clear_accel_measurement().await;
-            let start = embassy_time::Instant::now();
-            while embassy_time::Instant::now().duration_since(start).as_millis() < 20 {
+            let deadline = embassy_time::Instant::now() + GYRO_ACCEL_SAMPLE_TIMEOUT;
+            while embassy_time::Instant::now() < deadline {
                 if let Some(accel_data) = get_latest_accel_measurement().await {
                     accel_sum += accel_data;
                     accel_samples += 1;
@@ -365,65 +468,243 @@ async fn run_gyro_accel_calibration(run_gyro: bool, run_accel: bool) -> GyroAcce
     GyroAccelCalibrationResult { gyro_bias, accel_bias }
 }
 
-/// Gather magnetometer samples until coverage and sample thresholds are met.
-async fn measure_mag_coverage(config: MagCalibrationConfig) -> Option<MagCoverage> {
+/// Emit a phase transition log and update OLED with phase progress.
+async fn enter_mag_phase(phase: MagCalibrationPhase, detail: Option<&'static str>) {
     use crate::system::event;
 
-    let mut coverage = MagCoverage::new();
+    if let Some((index, total)) = phase.progress() {
+        info!("Mag phase transition -> {} ({}/{})", phase.label(), index, total);
+        let mut line1 = String::new();
+        let _ = write!(line1, "Phase {index}/{total}");
+        event::raise_event(event::Events::CalibrationStatus {
+            header: None,
+            line1: Some(line1),
+            line2: status_text(phase.label()),
+            line3: detail.and_then(status_text),
+        })
+        .await;
+    } else {
+        info!("Mag phase transition -> {}", phase.label());
+        event::raise_event(event::Events::CalibrationStatus {
+            header: None,
+            line1: status_text(phase.label()),
+            line2: detail.and_then(status_text),
+            line3: None,
+        })
+        .await;
+    }
+}
+
+/// Guide one explicit manual rotation phase and collect coverage.
+#[allow(clippy::too_many_lines)]
+#[allow(clippy::option_if_let_else)]
+async fn measure_mag_rotation_phase(
+    phase: MagCalibrationPhase,
+    step: &MagRotationStep,
+    config: MagCalibrationConfig,
+    coverage: &mut MagCoverage,
+) -> bool {
+    use crate::system::event;
+
+    enter_mag_phase(phase, Some("Rotate as shown")).await;
+
+    let step_timeout = (config.max_seconds / MAG_ROTATION_STEPS.len() as u64).max(10);
+    let min_step_samples = (config.min_samples / MAG_ROTATION_STEPS.len()).max(1);
+
+    let mut step_coverage = MagCoverage::new();
     let mut mag_timeout_streak: u32 = 0;
-    let mut last_status_secs: u64 = 0;
     let start_time = Instant::now();
-    let mut mag_failed = false;
+    let mut heading_min: f32 = f32::MAX;
+    let mut heading_max: f32 = f32::MIN;
+    let mut last_heading: Option<f32> = None;
+    let mut heading_offset: f32 = 0.0;
+    let mut last_log_ms: u32 = 0;
 
     loop {
         let elapsed_secs = Instant::now().duration_since(start_time).as_secs();
-        if elapsed_secs >= config.max_seconds {
-            mag_failed = true;
-            break;
+        if elapsed_secs >= step_timeout {
+            info!("Mag phase timeout at {}", phase.label());
+            return false;
         }
 
         clear_mag_measurement().await;
         if let Some(mag_data) = wait_for_mag_event_timeout(200).await {
             coverage.update(mag_data);
+            step_coverage.update(mag_data);
             mag_timeout_streak = 0;
+
+            if step.min_heading_span_deg.is_some() {
+                let heading_deg = libm::atan2f(mag_data.y, mag_data.x).to_degrees();
+                if let Some(prev) = last_heading {
+                    let delta = heading_deg - prev;
+                    if delta > 180.0 {
+                        heading_offset -= 360.0;
+                    } else if delta < -180.0 {
+                        heading_offset += 360.0;
+                    }
+                }
+                last_heading = Some(heading_deg);
+                let unwrapped = heading_deg + heading_offset;
+                heading_min = heading_min.min(unwrapped);
+                heading_max = heading_max.max(unwrapped);
+            }
         } else {
             mag_timeout_streak += 1;
         }
 
-        let axes_ok = coverage.axes_ok(config);
+        let (x_range, y_range, z_range) = step_coverage.ranges();
+        let heading_span = if step.min_heading_span_deg.is_some() {
+            heading_max - heading_min
+        } else {
+            0.0
+        };
+        let heading_span_ok = if let Some(min_span) = step.min_heading_span_deg {
+            heading_span >= min_span
+        } else {
+            true
+        };
 
-        if axes_ok == 3 && coverage.samples >= config.min_samples {
-            break;
+        let step_ok = (!step.require_x || x_range >= config.range_min_ut)
+            && (!step.require_y || y_range >= config.range_min_ut)
+            && (!step.require_z || z_range >= config.range_min_ut)
+            && heading_span_ok;
+
+        if step.min_heading_span_deg.is_some() {
+            #[allow(clippy::cast_possible_truncation)]
+            let now_ms = Instant::now().as_millis() as u32;
+            if now_ms.wrapping_sub(last_log_ms) >= 1000 {
+                last_log_ms = now_ms;
+                info!(
+                    "Yaw span {} deg (min={} max={}) samples={}",
+                    heading_span, heading_min, heading_max, step_coverage.samples
+                );
+            }
         }
 
-        if elapsed_secs != last_status_secs && elapsed_secs.is_multiple_of(config.status_interval_secs) {
-            last_status_secs = elapsed_secs;
-            let (x_range, y_range, z_range) = coverage.ranges();
-            let mut line_axes = String::new();
-            let _ = write!(line_axes, "Axes {axes_ok}/3");
-            let mut line_ranges = String::new();
-            let _ = write!(line_ranges, "X{x_range:.0} Y{y_range:.0} Z{z_range:.0}");
+        if step_ok && step_coverage.samples >= min_step_samples {
+            info!(
+                "Mag phase complete: {} (samples={})",
+                phase.label(),
+                step_coverage.samples
+            );
             event::raise_event(event::Events::CalibrationStatus {
                 header: None,
-                line1: None,
-                line2: Some(line_axes),
-                line3: Some(line_ranges),
+                line1: status_text("Phase OK"),
+                line2: status_text(step.label),
+                line3: status_text("Continue"),
             })
             .await;
+            Timer::after(Duration::from_millis(500)).await;
+            return true;
         }
 
+        let (line1, line2, line3) = match phase {
+            MagCalibrationPhase::ManualYaw => (
+                status_text("P1 YAW"),
+                status_text("Keep flat"),
+                status_text("Spin on table"),
+            ),
+            MagCalibrationPhase::ManualPitch => (
+                status_text("P2 PITCH"),
+                status_text("Tilt nose"),
+                status_text("Up / down"),
+            ),
+            MagCalibrationPhase::ManualRoll => (status_text("P3 ROLL"), status_text("Tilt left"), status_text("Right")),
+            _ => (
+                status_text(phase.label()),
+                status_text("Move slowly"),
+                status_text("Follow prompt"),
+            ),
+        };
+
+        event::raise_event(event::Events::CalibrationStatus {
+            header: None,
+            line1,
+            line2,
+            line3,
+        })
+        .await;
+
         if mag_timeout_streak >= config.timeout_limit {
-            mag_failed = true;
-            break;
+            info!("Mag phase timeout streak exceeded at {}", phase.label());
+            return false;
         }
+    }
+}
+
+/// Guide the user through explicit axis-specific phases and collect coverage.
+async fn measure_mag_coverage(config: MagCalibrationConfig) -> Option<MagCoverage> {
+    use crate::system::event;
+
+    let mut coverage = MagCoverage::new();
+
+    if !measure_mag_rotation_phase(
+        MagCalibrationPhase::ManualYaw,
+        &MAG_ROTATION_STEPS[0],
+        config,
+        &mut coverage,
+    )
+    .await
+    {
+        enter_mag_phase(MagCalibrationPhase::Failed, Some("Yaw incomplete")).await;
+        event::raise_event(event::Events::CalibrationStatus {
+            header: None,
+            line1: status_text("MAG FAILED"),
+            line2: status_text("Yaw incomplete"),
+            line3: status_text("Retry"),
+        })
+        .await;
+        Timer::after(Duration::from_secs(2)).await;
+        return None;
+    }
+
+    if !measure_mag_rotation_phase(
+        MagCalibrationPhase::ManualPitch,
+        &MAG_ROTATION_STEPS[1],
+        config,
+        &mut coverage,
+    )
+    .await
+    {
+        enter_mag_phase(MagCalibrationPhase::Failed, Some("Pitch incomplete")).await;
+        event::raise_event(event::Events::CalibrationStatus {
+            header: None,
+            line1: status_text("MAG FAILED"),
+            line2: status_text("Pitch incomplete"),
+            line3: status_text("Retry"),
+        })
+        .await;
+        Timer::after(Duration::from_secs(2)).await;
+        return None;
+    }
+
+    if !measure_mag_rotation_phase(
+        MagCalibrationPhase::ManualRoll,
+        &MAG_ROTATION_STEPS[2],
+        config,
+        &mut coverage,
+    )
+    .await
+    {
+        enter_mag_phase(MagCalibrationPhase::Failed, Some("Roll incomplete")).await;
+        event::raise_event(event::Events::CalibrationStatus {
+            header: None,
+            line1: status_text("MAG FAILED"),
+            line2: status_text("Roll incomplete"),
+            line3: status_text("Retry"),
+        })
+        .await;
+        Timer::after(Duration::from_secs(2)).await;
+        return None;
     }
 
     let axes_ok = coverage.axes_ok(config);
-    if mag_failed || coverage.samples == 0 || axes_ok < 3 {
+    if coverage.samples == 0 || axes_ok < 3 {
         info!(
-            "Mag calibration failed (samples={}, axes_ok={})",
+            "Mag calibration failed after manual phases (samples={}, axes_ok={})",
             coverage.samples, axes_ok
         );
+        enter_mag_phase(MagCalibrationPhase::Failed, Some("Coverage insufficient")).await;
         event::raise_event(event::Events::CalibrationStatus {
             header: None,
             line1: status_text("MAG FAILED"),
@@ -431,10 +712,25 @@ async fn measure_mag_coverage(config: MagCalibrationConfig) -> Option<MagCoverag
             line3: status_text("All axes"),
         })
         .await;
+        Timer::after(Duration::from_secs(2)).await;
         return None;
     }
 
     Some(coverage)
+}
+
+/// Enable or disable both motor driver chips during mag calibration.
+async fn set_motor_drivers_enabled(enabled: bool) {
+    motor_driver::send_motor_command(MotorCommand::SetDriverEnable {
+        track: Track::Left,
+        enabled,
+    })
+    .await;
+    motor_driver::send_motor_command(MotorCommand::SetDriverEnable {
+        track: Track::Right,
+        enabled,
+    })
+    .await;
 }
 
 /// Measure motor-induced magnetometer interference across predefined steps.
@@ -444,6 +740,7 @@ async fn measure_mag_interference(config: MagCalibrationConfig, baseline_mag: Ve
     let mut data = InterferenceData::new();
 
     for step in &INTERFERENCE_STEPS {
+        info!("Motor interference step start: {=str}", step.label);
         event::raise_event(event::Events::CalibrationStatus {
             header: None,
             line1: status_text("Mag interference"),
@@ -468,6 +765,7 @@ async fn measure_mag_interference(config: MagCalibrationConfig, baseline_mag: Ve
         let interference = subtract_mag(mag_avg, baseline_mag);
 
         data.set(step, interference);
+        info!("Motor interference step done: {=str}", step.label);
 
         motor_driver::send_motor_command(MotorCommand::CoastAll).await;
         Timer::after(Duration::from_millis(500)).await;
@@ -494,6 +792,12 @@ async fn verify_mag_interference(
     let baseline_norm = baseline_corrected.norm();
 
     for (index, step) in INTERFERENCE_STEPS.iter().enumerate() {
+        info!(
+            "Motor verify step {}/{}: {=str}",
+            index + 1,
+            INTERFERENCE_STEPS.len(),
+            step.label
+        );
         let mut line = String::new();
         let _ = write!(line, "Step {}/{}", index + 1, INTERFERENCE_STEPS.len());
         event::raise_event(event::Events::CalibrationStatus {
@@ -540,10 +844,11 @@ async fn verify_mag_interference(
 }
 
 /// Run the magnetometer calibration flow and return results on success.
+#[allow(clippy::too_many_lines)]
 async fn run_mag_calibration_steps(config: MagCalibrationConfig) -> Option<MagCalibrationResult> {
     use crate::system::event;
 
-    info!("Step 2: Magnetometer Calibration (manual rotation)");
+    info!("Step 2: Magnetometer Calibration (strict phase machine)");
     let (line1, line2, line3) = (status_text("Mag calibration"), status_text("Prepare to move"), None);
     event::raise_event(event::Events::CalibrationStatus {
         header: None,
@@ -567,7 +872,10 @@ async fn run_mag_calibration_steps(config: MagCalibrationConfig) -> Option<MagCa
     })
     .await;
 
-    let coverage = measure_mag_coverage(config).await?;
+    let Some(coverage) = measure_mag_coverage(config).await else {
+        info!("MAG CAL RESULT: reached_motor_phase=false, reason=manual coverage failed");
+        return None;
+    };
     let (x_range, y_range, z_range) = coverage.ranges();
 
     let mag_bias = Vector3::new(
@@ -593,18 +901,33 @@ async fn run_mag_calibration_steps(config: MagCalibrationConfig) -> Option<MagCa
         mag_scale.x, mag_scale.y, mag_scale.z
     );
 
-    motor_driver::send_motor_command(MotorCommand::SetDriverEnable {
-        track: Track::Left,
-        enabled: true,
+    enter_mag_phase(MagCalibrationPhase::SettleDelay, Some("Set robot down")).await;
+    event::raise_event(event::Events::CalibrationStatus {
+        header: None,
+        line1: status_text("Set down"),
+        line2: status_text("Hold still"),
+        line3: status_text("Motors in 20s"),
     })
     .await;
-    motor_driver::send_motor_command(MotorCommand::SetDriverEnable {
-        track: Track::Right,
-        enabled: true,
-    })
-    .await;
+
+    for remaining in (1..=20).rev() {
+        let mut line = String::new();
+        let _ = write!(line, "Motors in {remaining}s");
+        event::raise_event(event::Events::CalibrationStatus {
+            header: None,
+            line1: status_text("Set down"),
+            line2: status_text("Hold still"),
+            line3: Some(line),
+        })
+        .await;
+        Timer::after(Duration::from_secs(1)).await;
+    }
+
+    info!("Mag calibration entering motor phase");
+    set_motor_drivers_enabled(true).await;
     Timer::after(Duration::from_millis(100)).await;
 
+    enter_mag_phase(MagCalibrationPhase::MotorBaseline, Some("Motors off baseline")).await;
     event::raise_event(event::Events::CalibrationStatus {
         header: None,
         line1: status_text("Mag interference"),
@@ -617,13 +940,20 @@ async fn run_mag_calibration_steps(config: MagCalibrationConfig) -> Option<MagCa
     Timer::after(Duration::from_millis(500)).await;
     let baseline_mag = measure_mag_average(config.avg_samples).await;
 
+    enter_mag_phase(MagCalibrationPhase::MotorMeasure, Some("Run motor sequence")).await;
     let interference = measure_mag_interference(config, baseline_mag).await;
+
+    enter_mag_phase(MagCalibrationPhase::MotorVerify, Some("Verify compensation")).await;
     let verify_ok = verify_mag_interference(config, mag_bias, mag_scale, baseline_mag, &interference).await;
 
     motor_driver::send_motor_command(MotorCommand::CoastAll).await;
     Timer::after(Duration::from_millis(500)).await;
+    set_motor_drivers_enabled(false).await;
 
     if !verify_ok {
+        info!("Mag calibration failed in motor verify phase");
+        info!("MAG CAL RESULT: reached_motor_phase=true, reason=motor verify failed");
+        enter_mag_phase(MagCalibrationPhase::Failed, Some("Motor verify failed")).await;
         event::raise_event(event::Events::CalibrationStatus {
             header: None,
             line1: status_text("VERIFY FAIL"),
@@ -633,6 +963,9 @@ async fn run_mag_calibration_steps(config: MagCalibrationConfig) -> Option<MagCa
         .await;
         return None;
     }
+
+    enter_mag_phase(MagCalibrationPhase::Save, Some("Ready to save")).await;
+    info!("MAG CAL RESULT: reached_motor_phase=true, reason=success");
 
     Some(MagCalibrationResult {
         bias: mag_bias,
@@ -877,23 +1210,35 @@ async fn run_mag_calibration() {
     let mut imu_calibration = cached_calibration;
     let mut imu_flags = flash_storage::get_cached_imu_flags().await.unwrap_or_default();
 
-    if let Some(mag_result) = run_mag_calibration_steps(MAG_CALIBRATION_CONFIG).await {
-        imu_calibration.mag_x_bias = mag_result.bias.x;
-        imu_calibration.mag_y_bias = mag_result.bias.y;
-        imu_calibration.mag_z_bias = mag_result.bias.z;
-        imu_calibration.mag_x_scale = mag_result.scale.x;
-        imu_calibration.mag_y_scale = mag_result.scale.y;
-        imu_calibration.mag_z_scale = mag_result.scale.z;
-        imu_calibration.mag_x_interference_50 = mag_result.interference.x_50;
-        imu_calibration.mag_y_interference_50 = mag_result.interference.y_50;
-        imu_calibration.mag_z_interference_50 = mag_result.interference.z_50;
-        imu_calibration.mag_x_interference_100 = mag_result.interference.x_100;
-        imu_calibration.mag_y_interference_100 = mag_result.interference.y_100;
-        imu_calibration.mag_z_interference_100 = mag_result.interference.z_100;
-        imu_flags.mag = true;
-    } else {
+    let Some(mag_result) = run_mag_calibration_steps(MAG_CALIBRATION_CONFIG).await else {
         info!("Mag calibration failed; keeping previous values");
-    }
+        event::raise_event(event::Events::CalibrationStatus {
+            header: None,
+            line1: status_text("MAG FAILED"),
+            line2: status_text("Not saved"),
+            line3: None,
+        })
+        .await;
+        event::raise_event(event::Events::CalibrationCompleted).await;
+        Timer::after(Duration::from_secs(2)).await;
+
+        info!("=== IMU Mag Calibration Complete ===");
+        return;
+    };
+
+    imu_calibration.mag_x_bias = mag_result.bias.x;
+    imu_calibration.mag_y_bias = mag_result.bias.y;
+    imu_calibration.mag_z_bias = mag_result.bias.z;
+    imu_calibration.mag_x_scale = mag_result.scale.x;
+    imu_calibration.mag_y_scale = mag_result.scale.y;
+    imu_calibration.mag_z_scale = mag_result.scale.z;
+    imu_calibration.mag_x_interference_50 = mag_result.interference.x_50;
+    imu_calibration.mag_y_interference_50 = mag_result.interference.y_50;
+    imu_calibration.mag_z_interference_50 = mag_result.interference.z_50;
+    imu_calibration.mag_x_interference_100 = mag_result.interference.x_100;
+    imu_calibration.mag_y_interference_100 = mag_result.interference.y_100;
+    imu_calibration.mag_z_interference_100 = mag_result.interference.z_100;
+    imu_flags.mag = true;
 
     info!("Saving mag calibration to flash");
     info!("╔═══════════════════════════════════════════════════╗");

--- a/src/task/drive/calibration/imu.rs
+++ b/src/task/drive/calibration/imu.rs
@@ -7,6 +7,8 @@ use core::fmt::Write;
 
 use defmt::info;
 use embassy_time::{Duration, Instant, Timer};
+use heapless::String;
+use nalgebra::Vector3;
 
 use crate::{
     system::helper::string_helper::status_text,
@@ -21,6 +23,604 @@ use crate::{
         motor_driver::{self, MotorCommand, Track},
     },
 };
+
+#[derive(Copy, Clone)]
+/// Thresholds and timing used by magnetometer calibration.
+struct MagCalibrationConfig {
+    /// Max consecutive mag read timeouts before failing.
+    timeout_limit: u32,
+    /// Max time allowed for the rotation coverage phase.
+    max_seconds: u64,
+    /// Minimum axis range (μT) required per axis.
+    range_min_ut: f32,
+    /// Minimum samples required before accepting coverage.
+    min_samples: usize,
+    /// Samples per averaging window (baseline + interference).
+    avg_samples: u16,
+    /// Minimum acceptable corrected field magnitude (μT).
+    verify_min_ut: f32,
+    /// Maximum acceptable corrected field magnitude (μT).
+    verify_max_ut: f32,
+    /// Max allowed delta from baseline magnitude (μT).
+    verify_max_delta_ut: f32,
+    /// Status update cadence (seconds).
+    status_interval_secs: u64,
+}
+
+/// Default magnetometer calibration thresholds.
+const MAG_CALIBRATION_CONFIG: MagCalibrationConfig = MagCalibrationConfig {
+    timeout_limit: 25, // ~5s at 200ms
+    max_seconds: 90,
+    range_min_ut: 30.0,
+    min_samples: 500,
+    avg_samples: 250, // ~5s at 50Hz
+    verify_min_ut: 20.0,
+    verify_max_ut: 200.0,
+    verify_max_delta_ut: 20.0,
+    status_interval_secs: 2,
+};
+
+#[derive(Copy, Clone)]
+/// Motor command step used to measure or verify mag interference.
+struct InterferenceStep {
+    /// UI label for the step.
+    label: &'static str,
+    /// Left track command percentage.
+    left: i8,
+    /// Right track command percentage.
+    right: i8,
+    /// Nominal speed bucket (50 or 100).
+    speed: u8,
+    /// Slot index for storing results.
+    slot: usize,
+}
+
+/// Sequence of steps for interference measurement and verification.
+const INTERFERENCE_STEPS: [InterferenceStep; 6] = [
+    InterferenceStep {
+        label: "All 50%",
+        left: 50,
+        right: 50,
+        speed: 50,
+        slot: 0,
+    },
+    InterferenceStep {
+        label: "All 100%",
+        left: 100,
+        right: 100,
+        speed: 100,
+        slot: 0,
+    },
+    InterferenceStep {
+        label: "Left 50%",
+        left: 50,
+        right: 0,
+        speed: 50,
+        slot: 1,
+    },
+    InterferenceStep {
+        label: "Left 100%",
+        left: 100,
+        right: 0,
+        speed: 100,
+        slot: 1,
+    },
+    InterferenceStep {
+        label: "Right 50%",
+        left: 0,
+        right: 50,
+        speed: 50,
+        slot: 2,
+    },
+    InterferenceStep {
+        label: "Right 100%",
+        left: 0,
+        right: 100,
+        speed: 100,
+        slot: 2,
+    },
+];
+
+/// Tracks coverage of magnetometer readings during manual rotation.
+struct MagCoverage {
+    /// Minimum X reading observed.
+    x_min: f32,
+    /// Maximum X reading observed.
+    x_max: f32,
+    /// Minimum Y reading observed.
+    y_min: f32,
+    /// Maximum Y reading observed.
+    y_max: f32,
+    /// Minimum Z reading observed.
+    z_min: f32,
+    /// Maximum Z reading observed.
+    z_max: f32,
+    /// Total samples collected.
+    samples: usize,
+}
+
+impl MagCoverage {
+    /// Create an empty coverage tracker.
+    const fn new() -> Self {
+        Self {
+            x_min: f32::MAX,
+            x_max: f32::MIN,
+            y_min: f32::MAX,
+            y_max: f32::MIN,
+            z_min: f32::MAX,
+            z_max: f32::MIN,
+            samples: 0,
+        }
+    }
+
+    /// Update min/max ranges with a new magnetometer sample.
+    fn update(&mut self, mag: Vector3<f32>) {
+        self.samples += 1;
+        self.x_min = self.x_min.min(mag.x);
+        self.x_max = self.x_max.max(mag.x);
+        self.y_min = self.y_min.min(mag.y);
+        self.y_max = self.y_max.max(mag.y);
+        self.z_min = self.z_min.min(mag.z);
+        self.z_max = self.z_max.max(mag.z);
+    }
+
+    /// Return the span of each axis (max - min).
+    const fn ranges(&self) -> (f32, f32, f32) {
+        (
+            self.x_max - self.x_min,
+            self.y_max - self.y_min,
+            self.z_max - self.z_min,
+        )
+    }
+
+    /// Count how many axes meet the minimum coverage requirement.
+    const fn axes_ok(&self, config: MagCalibrationConfig) -> u8 {
+        let (x_range, y_range, z_range) = self.ranges();
+        (if x_range >= config.range_min_ut { 1 } else { 0 })
+            + (if y_range >= config.range_min_ut { 1 } else { 0 })
+            + (if z_range >= config.range_min_ut { 1 } else { 0 })
+    }
+}
+
+/// Captured motor interference vectors at 50% and 100% commands.
+struct InterferenceData {
+    /// X-axis interference at 50% (all, left, right).
+    x_50: [f32; 3],
+    /// Y-axis interference at 50% (all, left, right).
+    y_50: [f32; 3],
+    /// Z-axis interference at 50% (all, left, right).
+    z_50: [f32; 3],
+    /// X-axis interference at 100% (all, left, right).
+    x_100: [f32; 3],
+    /// Y-axis interference at 100% (all, left, right).
+    y_100: [f32; 3],
+    /// Z-axis interference at 100% (all, left, right).
+    z_100: [f32; 3],
+}
+
+impl InterferenceData {
+    /// Create empty interference buffers.
+    const fn new() -> Self {
+        Self {
+            x_50: [0.0; 3],
+            y_50: [0.0; 3],
+            z_50: [0.0; 3],
+            x_100: [0.0; 3],
+            y_100: [0.0; 3],
+            z_100: [0.0; 3],
+        }
+    }
+
+    /// Store the measured interference vector for a step.
+    fn set(&mut self, step: &InterferenceStep, interference: Vector3<f32>) {
+        if step.speed == 50 {
+            self.x_50[step.slot] = interference.x;
+            self.y_50[step.slot] = interference.y;
+            self.z_50[step.slot] = interference.z;
+        } else {
+            self.x_100[step.slot] = interference.x;
+            self.y_100[step.slot] = interference.y;
+            self.z_100[step.slot] = interference.z;
+        }
+    }
+
+    /// Retrieve the interference vector for a step.
+    const fn vector_for(&self, step: &InterferenceStep) -> Vector3<f32> {
+        if step.speed == 50 {
+            Vector3::new(self.x_50[step.slot], self.y_50[step.slot], self.z_50[step.slot])
+        } else {
+            Vector3::new(self.x_100[step.slot], self.y_100[step.slot], self.z_100[step.slot])
+        }
+    }
+}
+
+/// Output of magnetometer calibration.
+struct MagCalibrationResult {
+    /// Hard-iron bias in μT.
+    bias: Vector3<f32>,
+    /// Soft-iron scale factors.
+    scale: Vector3<f32>,
+    /// Motor interference measurements.
+    interference: InterferenceData,
+}
+
+/// Collect stationary samples and compute gyro/accel bias vectors.
+async fn run_gyro_accel_calibration(run_gyro: bool, run_accel: bool) -> (Vector3<f32>, Vector3<f32>) {
+    use crate::system::event;
+
+    let step_label = if run_gyro && run_accel {
+        "Gyro+Accel cal"
+    } else if run_gyro {
+        "Gyro calibration"
+    } else {
+        "Accel calibration"
+    };
+    info!("Step 1: {=str}", step_label);
+    let (line1, line2, line3) = (status_text(step_label), status_text("Keep still 10s"), None);
+    event::raise_event(event::Events::CalibrationStatus {
+        header: None,
+        line1,
+        line2,
+        line3,
+    })
+    .await;
+
+    info!("  Collecting calibration samples (stationary)...");
+    let mut gyro_sum = Vector3::new(0.0f32, 0.0f32, 0.0f32);
+    let mut accel_sum = Vector3::new(0.0f32, 0.0f32, 0.0f32);
+    let num_samples: u16 = 500; // 500 samples at 50Hz = 10 seconds
+    let num_samples_f32 = f32::from(num_samples);
+
+    if run_gyro {
+        clear_gyro_measurement().await;
+    }
+    if run_accel {
+        clear_accel_measurement().await;
+    }
+    Timer::after(Duration::from_millis(100)).await;
+
+    for i in 0..num_samples {
+        if run_gyro {
+            let start = embassy_time::Instant::now();
+            while embassy_time::Instant::now().duration_since(start).as_millis() < 20 {
+                if let Some(gyro_data) = get_latest_gyro_measurement().await {
+                    gyro_sum += gyro_data;
+                    break;
+                }
+                Timer::after(Duration::from_millis(1)).await;
+            }
+        }
+
+        if run_accel {
+            let start = embassy_time::Instant::now();
+            while embassy_time::Instant::now().duration_since(start).as_millis() < 20 {
+                if let Some(accel_data) = get_latest_accel_measurement().await {
+                    accel_sum += accel_data;
+                    break;
+                }
+                Timer::after(Duration::from_millis(1)).await;
+            }
+        }
+
+        if i % 50 == 0 {
+            let progress = (u32::from(i) * 100) / u32::from(num_samples);
+            let mut line = String::new();
+            let _ = write!(line, "Progress: {progress}%");
+            event::raise_event(event::Events::CalibrationStatus {
+                header: None,
+                line1: None,
+                line2: None,
+                line3: Some(line),
+            })
+            .await;
+        }
+    }
+
+    let computed_gyro_bias = if run_gyro {
+        gyro_sum / num_samples_f32
+    } else {
+        Vector3::new(0.0, 0.0, 0.0)
+    };
+    let computed_accel_bias = if run_accel {
+        let mut bias = accel_sum / num_samples_f32;
+        bias.z -= 1.0;
+        bias
+    } else {
+        Vector3::new(0.0, 0.0, 0.0)
+    };
+
+    if run_gyro {
+        info!("  ✓ Gyro bias calculated:");
+        info!("    X: {} deg/s", computed_gyro_bias.x);
+        info!("    Y: {} deg/s", computed_gyro_bias.y);
+        info!("    Z: {} deg/s", computed_gyro_bias.z);
+    }
+
+    if run_accel {
+        info!("  ✓ Accel bias calculated:");
+        info!("    X: {} g", computed_accel_bias.x);
+        info!("    Y: {} g", computed_accel_bias.y);
+        info!("    Z: {} g (gravity removed)", computed_accel_bias.z);
+    }
+
+    (computed_gyro_bias, computed_accel_bias)
+}
+
+/// Gather magnetometer samples until coverage and sample thresholds are met.
+async fn measure_mag_coverage(config: MagCalibrationConfig) -> Option<MagCoverage> {
+    use crate::system::event;
+
+    let mut coverage = MagCoverage::new();
+    let mut mag_timeout_streak: u32 = 0;
+    let mut last_status_secs: u64 = 0;
+    let start_time = Instant::now();
+    let mut mag_failed = false;
+
+    loop {
+        let elapsed_secs = Instant::now().duration_since(start_time).as_secs();
+        if elapsed_secs >= config.max_seconds {
+            mag_failed = true;
+            break;
+        }
+
+        clear_mag_measurement().await;
+        if let Some(mag_data) = wait_for_mag_event_timeout(200).await {
+            coverage.update(mag_data);
+            mag_timeout_streak = 0;
+        } else {
+            mag_timeout_streak += 1;
+        }
+
+        let axes_ok = coverage.axes_ok(config);
+
+        if axes_ok == 3 && coverage.samples >= config.min_samples {
+            break;
+        }
+
+        if elapsed_secs != last_status_secs && elapsed_secs.is_multiple_of(config.status_interval_secs) {
+            last_status_secs = elapsed_secs;
+            let (x_range, y_range, z_range) = coverage.ranges();
+            let mut line_axes = String::new();
+            let _ = write!(line_axes, "Axes {axes_ok}/3");
+            let mut line_ranges = String::new();
+            let _ = write!(line_ranges, "X{x_range:.0} Y{y_range:.0} Z{z_range:.0}");
+            event::raise_event(event::Events::CalibrationStatus {
+                header: None,
+                line1: None,
+                line2: Some(line_axes),
+                line3: Some(line_ranges),
+            })
+            .await;
+        }
+
+        if mag_timeout_streak >= config.timeout_limit {
+            mag_failed = true;
+            break;
+        }
+    }
+
+    let axes_ok = coverage.axes_ok(config);
+    if mag_failed || coverage.samples == 0 || axes_ok < 3 {
+        info!(
+            "Mag calibration failed (samples={}, axes_ok={})",
+            coverage.samples, axes_ok
+        );
+        event::raise_event(event::Events::CalibrationStatus {
+            header: None,
+            line1: status_text("MAG FAILED"),
+            line2: status_text("Rotate more"),
+            line3: status_text("All axes"),
+        })
+        .await;
+        return None;
+    }
+
+    Some(coverage)
+}
+
+/// Measure motor-induced magnetometer interference across predefined steps.
+async fn measure_mag_interference(config: MagCalibrationConfig, baseline_mag: Vector3<f32>) -> InterferenceData {
+    use crate::system::event;
+
+    let mut data = InterferenceData::new();
+
+    for step in &INTERFERENCE_STEPS {
+        event::raise_event(event::Events::CalibrationStatus {
+            header: None,
+            line1: status_text("Mag interference"),
+            line2: status_text(step.label),
+            line3: status_text("Measuring 5s"),
+        })
+        .await;
+
+        motor_driver::send_motor_command(MotorCommand::SetTrack {
+            track: Track::Left,
+            speed: step.left,
+        })
+        .await;
+        motor_driver::send_motor_command(MotorCommand::SetTrack {
+            track: Track::Right,
+            speed: step.right,
+        })
+        .await;
+        Timer::after(Duration::from_millis(1000)).await;
+        clear_mag_measurement().await;
+        let mag_avg = measure_mag_average(config.avg_samples).await;
+        let interference = subtract_mag(mag_avg, baseline_mag);
+
+        data.set(step, interference);
+
+        motor_driver::send_motor_command(MotorCommand::CoastAll).await;
+        Timer::after(Duration::from_millis(500)).await;
+    }
+
+    data
+}
+
+/// Verify interference compensation keeps the field within expected limits.
+async fn verify_mag_interference(
+    config: MagCalibrationConfig,
+    bias: Vector3<f32>,
+    scale: Vector3<f32>,
+    baseline_mag: Vector3<f32>,
+    interference: &InterferenceData,
+) -> bool {
+    use crate::system::event;
+
+    let baseline_corrected = Vector3::new(
+        (baseline_mag.x - bias.x) * scale.x,
+        (baseline_mag.y - bias.y) * scale.y,
+        (baseline_mag.z - bias.z) * scale.z,
+    );
+    let baseline_norm = baseline_corrected.norm();
+
+    for (index, step) in INTERFERENCE_STEPS.iter().enumerate() {
+        let mut line = String::new();
+        let _ = write!(line, "Step {}/{}", index + 1, INTERFERENCE_STEPS.len());
+        event::raise_event(event::Events::CalibrationStatus {
+            header: None,
+            line1: status_text("Mag verify"),
+            line2: status_text(step.label),
+            line3: Some(line),
+        })
+        .await;
+
+        motor_driver::send_motor_command(MotorCommand::SetTrack {
+            track: Track::Left,
+            speed: step.left,
+        })
+        .await;
+        motor_driver::send_motor_command(MotorCommand::SetTrack {
+            track: Track::Right,
+            speed: step.right,
+        })
+        .await;
+        Timer::after(Duration::from_millis(1000)).await;
+        clear_mag_measurement().await;
+        let mag_avg = measure_mag_average(config.avg_samples).await;
+
+        let interference_vec = interference.vector_for(step);
+        let mut corrected = subtract_mag(mag_avg, interference_vec);
+        corrected.x = (corrected.x - bias.x) * scale.x;
+        corrected.y = (corrected.y - bias.y) * scale.y;
+        corrected.z = (corrected.z - bias.z) * scale.z;
+
+        let mag_norm = corrected.norm();
+        if mag_norm < config.verify_min_ut
+            || mag_norm > config.verify_max_ut
+            || (mag_norm - baseline_norm).abs() > config.verify_max_delta_ut
+        {
+            return false;
+        }
+
+        motor_driver::send_motor_command(MotorCommand::CoastAll).await;
+        Timer::after(Duration::from_millis(500)).await;
+    }
+
+    true
+}
+
+/// Run the magnetometer calibration flow and return results on success.
+async fn run_mag_calibration_steps(config: MagCalibrationConfig) -> Option<MagCalibrationResult> {
+    use crate::system::event;
+
+    info!("Step 2: Magnetometer Calibration (manual rotation)");
+    let (line1, line2, line3) = (status_text("Mag calibration"), status_text("Prepare to move"), None);
+    event::raise_event(event::Events::CalibrationStatus {
+        header: None,
+        line1,
+        line2,
+        line3,
+    })
+    .await;
+    Timer::after(Duration::from_secs(3)).await;
+
+    let (line1, line2, line3) = (
+        status_text("Mag calibration"),
+        status_text("Rotate slowly"),
+        status_text("Pitch/Roll/Yaw"),
+    );
+    event::raise_event(event::Events::CalibrationStatus {
+        header: None,
+        line1,
+        line2,
+        line3,
+    })
+    .await;
+
+    let coverage = measure_mag_coverage(config).await?;
+    let (x_range, y_range, z_range) = coverage.ranges();
+
+    let mag_bias = Vector3::new(
+        f32::midpoint(coverage.x_max, coverage.x_min),
+        f32::midpoint(coverage.y_max, coverage.y_min),
+        f32::midpoint(coverage.z_max, coverage.z_min),
+    );
+
+    let x_radius = x_range / 2.0;
+    let y_radius = y_range / 2.0;
+    let z_radius = z_range / 2.0;
+    let avg_radius = (x_radius + y_radius + z_radius) / 3.0;
+
+    let mag_scale = Vector3::new(avg_radius / x_radius, avg_radius / y_radius, avg_radius / z_radius);
+
+    info!("  ✓ Magnetometer coverage complete!");
+    info!(
+        "  Hard iron bias (μT): X={} Y={} Z={}",
+        mag_bias.x, mag_bias.y, mag_bias.z
+    );
+    info!(
+        "  Soft iron scale: X={} Y={} Z={}",
+        mag_scale.x, mag_scale.y, mag_scale.z
+    );
+
+    motor_driver::send_motor_command(MotorCommand::SetDriverEnable {
+        track: Track::Left,
+        enabled: true,
+    })
+    .await;
+    motor_driver::send_motor_command(MotorCommand::SetDriverEnable {
+        track: Track::Right,
+        enabled: true,
+    })
+    .await;
+    Timer::after(Duration::from_millis(100)).await;
+
+    event::raise_event(event::Events::CalibrationStatus {
+        header: None,
+        line1: status_text("Mag interference"),
+        line2: status_text("Baseline (OFF)"),
+        line3: status_text("Measuring 5s"),
+    })
+    .await;
+
+    clear_mag_measurement().await;
+    Timer::after(Duration::from_millis(500)).await;
+    let baseline_mag = measure_mag_average(config.avg_samples).await;
+
+    let interference = measure_mag_interference(config, baseline_mag).await;
+    let verify_ok = verify_mag_interference(config, mag_bias, mag_scale, baseline_mag, &interference).await;
+
+    motor_driver::send_motor_command(MotorCommand::CoastAll).await;
+    Timer::after(Duration::from_millis(500)).await;
+
+    if !verify_ok {
+        event::raise_event(event::Events::CalibrationStatus {
+            header: None,
+            line1: status_text("VERIFY FAIL"),
+            line2: status_text("Recalibrate"),
+            line3: status_text("Motors/mag"),
+        })
+        .await;
+        return None;
+    }
+
+    Some(MagCalibrationResult {
+        bias: mag_bias,
+        scale: mag_scale,
+        interference,
+    })
+}
 
 /// Run the IMU calibration procedure
 ///
@@ -49,40 +649,14 @@ use crate::{
 #[allow(clippy::too_many_lines)]
 #[allow(clippy::similar_names)]
 #[allow(clippy::cast_precision_loss)]
-pub async fn run_imu_calibration(kind: ImuCalibrationKind) {
-    use heapless::String;
-
+async fn run_gyro_calibration() {
     use crate::{
         system::event,
         task::{io::flash_storage, sensors::imu as imu_read},
     };
 
-    info!("=== Starting IMU Calibration ===");
+    info!("=== Starting IMU Gyro Calibration ===");
 
-    let run_gyro = matches!(kind, ImuCalibrationKind::Gyro);
-    let run_accel = matches!(kind, ImuCalibrationKind::Accel);
-    let run_mag = matches!(kind, ImuCalibrationKind::Mag);
-
-    let cached_calibration = flash_storage::get_cached_imu_calibration().await.unwrap_or_default();
-    let mut gyro_x_bias = cached_calibration.gyro_x_bias;
-    let mut gyro_y_bias = cached_calibration.gyro_y_bias;
-    let mut gyro_z_bias = cached_calibration.gyro_z_bias;
-    let mut accel_x_bias = cached_calibration.accel_x_bias;
-    let mut accel_y_bias = cached_calibration.accel_y_bias;
-    let mut accel_z_bias = cached_calibration.accel_z_bias;
-    let mut mag_x_bias = cached_calibration.mag_x_bias;
-    let mut mag_y_bias = cached_calibration.mag_y_bias;
-    let mut mag_z_bias = cached_calibration.mag_z_bias;
-    let mut mag_x_interference_50 = cached_calibration.mag_x_interference_50;
-    let mut mag_y_interference_50 = cached_calibration.mag_y_interference_50;
-    let mut mag_z_interference_50 = cached_calibration.mag_z_interference_50;
-    let mut mag_x_interference_100 = cached_calibration.mag_x_interference_100;
-    let mut mag_y_interference_100 = cached_calibration.mag_y_interference_100;
-    let mut mag_z_interference_100 = cached_calibration.mag_z_interference_100;
-    let mut imu_flags = flash_storage::get_cached_imu_flags().await.unwrap_or_default();
-    let mut mag_completed = false;
-
-    // Display calibration header
     event::raise_event(event::Events::CalibrationStatus {
         header: status_text("IMU Calibration"),
         line1: status_text("Initializing"),
@@ -91,551 +665,30 @@ pub async fn run_imu_calibration(kind: ImuCalibrationKind) {
     })
     .await;
 
-    if run_gyro || run_accel || run_mag {
-        imu_read::start_imu_readings();
-        Timer::after(Duration::from_millis(500)).await; // Wait for IMU to start
-    }
+    imu_read::start_imu_readings();
+    Timer::after(Duration::from_millis(500)).await;
 
-    if run_gyro || run_accel {
-        // Step 1: Gyroscope and/or Accelerometer Calibration (stationary)
-        let step_label = if run_gyro && run_accel {
-            "Gyro+Accel cal"
-        } else if run_gyro {
-            "Gyro calibration"
-        } else {
-            "Accel calibration"
-        };
-        info!("Step 1: {=str}", step_label);
-        let (line1, line2, line3) = (status_text(step_label), status_text("Keep still 10s"), None);
-        event::raise_event(event::Events::CalibrationStatus {
-            header: None,
-            line1,
-            line2,
-            line3,
-        })
-        .await;
+    let cached_calibration = flash_storage::get_cached_imu_calibration().await.unwrap_or_default();
+    let mut imu_calibration = cached_calibration;
+    let mut imu_flags = flash_storage::get_cached_imu_flags().await.unwrap_or_default();
 
-        // Collect gyro and accel samples while stationary
-        info!("  Collecting calibration samples (stationary)...");
-        let mut gyro_x_sum = 0.0f32;
-        let mut gyro_y_sum = 0.0f32;
-        let mut gyro_z_sum = 0.0f32;
-        let mut accel_x_sum = 0.0f32;
-        let mut accel_y_sum = 0.0f32;
-        let mut accel_z_sum = 0.0f32;
-        let num_samples = 1000; // 1000 samples at 100Hz = 10 seconds
+    let (gyro_bias, _) = run_gyro_accel_calibration(true, false).await;
+    imu_calibration.gyro_x_bias = gyro_bias.x;
+    imu_calibration.gyro_y_bias = gyro_bias.y;
+    imu_calibration.gyro_z_bias = gyro_bias.z;
+    imu_flags.gyro = true;
 
-        if run_gyro {
-            clear_gyro_measurement().await;
-        }
-        if run_accel {
-            clear_accel_measurement().await;
-        }
-        Timer::after(Duration::from_millis(100)).await; // Wait for fresh data
-
-        for i in 0..num_samples {
-            if run_gyro {
-                // Wait for fresh gyro data
-                let start = embassy_time::Instant::now();
-                while embassy_time::Instant::now().duration_since(start).as_millis() < 20 {
-                    if let Some(gyro_data) = get_latest_gyro_measurement().await {
-                        gyro_x_sum += gyro_data.x;
-                        gyro_y_sum += gyro_data.y;
-                        gyro_z_sum += gyro_data.z;
-                        break;
-                    }
-                    Timer::after(Duration::from_millis(1)).await;
-                }
-            }
-
-            if run_accel {
-                // Wait for fresh accel data
-                let start = embassy_time::Instant::now();
-                while embassy_time::Instant::now().duration_since(start).as_millis() < 20 {
-                    if let Some(accel_data) = get_latest_accel_measurement().await {
-                        accel_x_sum += accel_data.x;
-                        accel_y_sum += accel_data.y;
-                        accel_z_sum += accel_data.z;
-                        break;
-                    }
-                    Timer::after(Duration::from_millis(1)).await;
-                }
-            }
-
-            // Update progress every 100 samples
-            if i % 100 == 0 {
-                let progress = (i * 100) / num_samples;
-                let mut line = String::new();
-                let _ = write!(line, "Progress: {progress}%");
-                event::raise_event(event::Events::CalibrationStatus {
-                    header: None,
-                    line1: None,
-                    line2: None,
-                    line3: Some(line),
-                })
-                .await;
-            }
-        }
-
-        let computed_gyro_x_bias = gyro_x_sum / num_samples as f32;
-        let computed_gyro_y_bias = gyro_y_sum / num_samples as f32;
-        let computed_gyro_z_bias = gyro_z_sum / num_samples as f32;
-        let computed_accel_x_bias = accel_x_sum / num_samples as f32;
-        let computed_accel_y_bias = accel_y_sum / num_samples as f32;
-        let computed_accel_z_bias = (accel_z_sum / num_samples as f32) - 1.0; // Subtract 1g for gravity
-
-        if run_gyro {
-            gyro_x_bias = computed_gyro_x_bias;
-            gyro_y_bias = computed_gyro_y_bias;
-            gyro_z_bias = computed_gyro_z_bias;
-
-            info!("  ✓ Gyro bias calculated:");
-            info!("    X: {} deg/s", gyro_x_bias);
-            info!("    Y: {} deg/s", gyro_y_bias);
-            info!("    Z: {} deg/s", gyro_z_bias);
-        }
-
-        if run_accel {
-            accel_x_bias = computed_accel_x_bias;
-            accel_y_bias = computed_accel_y_bias;
-            accel_z_bias = computed_accel_z_bias;
-
-            info!("  ✓ Accel bias calculated:");
-            info!("    X: {} g", accel_x_bias);
-            info!("    Y: {} g", accel_y_bias);
-            info!("    Z: {} g (gravity removed)", accel_z_bias);
-        }
-    }
-
-    if run_mag {
-        const MAG_TIMEOUT_LIMIT: u32 = 25; // ~5s at 200ms
-        const MAG_MAX_SECONDS: u64 = 90;
-
-        // Step 2: Magnetometer Calibration (moving through all axes)
-        info!("Step 2: Magnetometer Calibration (CRITICAL - Manual Rotation Required)");
-        let (line1, line2, line3) = (status_text("Mag calibration"), status_text("Prepare to move"), None);
-        event::raise_event(event::Events::CalibrationStatus {
-            header: None,
-            line1,
-            line2,
-            line3,
-        })
-        .await;
-        Timer::after(Duration::from_secs(3)).await;
-
-        let (line1, line2, line3) = (
-            status_text("Mag calibration"),
-            status_text("Rotate slowly"),
-            status_text("All axes 60s"),
-        );
-        event::raise_event(event::Events::CalibrationStatus {
-            header: None,
-            line1,
-            line2,
-            line3,
-        })
-        .await;
-
-        info!("╔═══════════════════════════════════════════════════╗");
-        info!("║  CRITICAL: MAGNETOMETER CALIBRATION REQUIRED     ║");
-        info!("╠═══════════════════════════════════════════════════╣");
-        info!("║  Slowly rotate robot through ALL axes for 60s:   ║");
-        info!("║  • PITCH: Tilt forward/backward                  ║");
-        info!("║  • ROLL: Tilt left/right                         ║");
-        info!("║  • YAW: Spin clockwise/counterclockwise          ║");
-        info!("║                                                   ║");
-        info!("║  Goal: Robot must experience full 3D rotation    ║");
-        info!("║  to map Earth's magnetic field in all            ║");
-        info!("║  orientations. Move slowly and smoothly.         ║");
-        info!("╚═══════════════════════════════════════════════════╝");
-
-        // Collect magnetometer samples to find min/max for hard iron calibration
-        let mut mag_x_min = f32::MAX;
-        let mut mag_x_max = f32::MIN;
-        let mut mag_y_min = f32::MAX;
-        let mut mag_y_max = f32::MIN;
-        let mut mag_z_min = f32::MAX;
-        let mut mag_z_max = f32::MIN;
-        let mag_samples = 6000; // 6000 samples at 100Hz = 60 seconds
-        let mut mag_samples_collected: usize = 0;
-        let mut mag_timeout_streak: u32 = 0;
-        let mut last_status_secs: u64 = 0;
-        let start_time = Instant::now();
-        let mut mag_failed = false;
-
-        while mag_samples_collected < mag_samples {
-            let elapsed_ms = Instant::now().duration_since(start_time).as_millis();
-            let elapsed_secs = elapsed_ms / 1000;
-
-            if elapsed_secs >= MAG_MAX_SECONDS {
-                mag_failed = true;
-                break;
-            }
-
-            if let Some(mag_data) = wait_for_mag_event_timeout(200).await {
-                mag_samples_collected += 1;
-                mag_timeout_streak = 0;
-
-                // Track min/max for each axis
-                if mag_data.x < mag_x_min {
-                    mag_x_min = mag_data.x;
-                }
-                if mag_data.x > mag_x_max {
-                    mag_x_max = mag_data.x;
-                }
-                if mag_data.y < mag_y_min {
-                    mag_y_min = mag_data.y;
-                }
-                if mag_data.y > mag_y_max {
-                    mag_y_max = mag_data.y;
-                }
-                if mag_data.z < mag_z_min {
-                    mag_z_min = mag_data.z;
-                }
-                if mag_data.z > mag_z_max {
-                    mag_z_max = mag_data.z;
-                }
-            } else {
-                mag_timeout_streak += 1;
-            }
-
-            if elapsed_secs.is_multiple_of(5) && elapsed_secs != last_status_secs {
-                last_status_secs = elapsed_secs;
-                let mut line = String::new();
-                let _ = write!(line, "S:{mag_samples_collected}/{mag_samples} T:{elapsed_secs}s");
-                event::raise_event(event::Events::CalibrationStatus {
-                    header: None,
-                    line1: None,
-                    line2: None,
-                    line3: Some(line),
-                })
-                .await;
-            }
-
-            if mag_timeout_streak >= MAG_TIMEOUT_LIMIT {
-                mag_failed = true;
-                break;
-            }
-        }
-
-        if mag_failed || mag_samples_collected == 0 {
-            info!("Mag calibration timed out ({} samples)", mag_samples_collected);
-            event::raise_event(event::Events::CalibrationStatus {
-                header: None,
-                line1: status_text("MAG TIMEOUT"),
-                line2: status_text("Check IMU"),
-                line3: status_text("No mag data"),
-            })
-            .await;
-        } else {
-            // Calculate hard iron bias (center of min/max sphere)
-            let computed_mag_x_bias = f32::midpoint(mag_x_max, mag_x_min);
-            let computed_mag_y_bias = f32::midpoint(mag_y_max, mag_y_min);
-            let computed_mag_z_bias = f32::midpoint(mag_z_max, mag_z_min);
-
-            mag_x_bias = computed_mag_x_bias;
-            mag_y_bias = computed_mag_y_bias;
-            mag_z_bias = computed_mag_z_bias;
-
-            info!("  ✓ Magnetometer calibration complete!");
-            info!("  Hard iron bias (offset to center):");
-            info!("    X: min={} max={} → bias={}", mag_x_min, mag_x_max, mag_x_bias);
-            info!("    Y: min={} max={} → bias={}", mag_y_min, mag_y_max, mag_y_bias);
-            info!("    Z: min={} max={} → bias={}", mag_z_min, mag_z_max, mag_z_bias);
-
-            // Enable motor drivers for interference testing
-            info!("Enabling motor driver chips");
-            motor_driver::send_motor_command(MotorCommand::SetDriverEnable {
-                track: Track::Left,
-                enabled: true,
-            })
-            .await;
-            motor_driver::send_motor_command(MotorCommand::SetDriverEnable {
-                track: Track::Right,
-                enabled: true,
-            })
-            .await;
-            Timer::after(Duration::from_millis(100)).await;
-
-            // Step 3: Motor interference baseline (motors off)
-            info!("Step 3: Measuring magnetic baseline (motors OFF)");
-            event::raise_event(event::Events::CalibrationStatus {
-                header: None,
-                line1: status_text("Mag interference"),
-                line2: status_text("Baseline (OFF)"),
-                line3: status_text("5 seconds..."),
-            })
-            .await;
-
-            clear_mag_measurement().await;
-            Timer::after(Duration::from_millis(500)).await; // Wait for fresh data
-            let baseline_mag = measure_mag_average(500).await; // 500 samples at 100Hz = 5s
-            info!(
-                "  Baseline mag: x={} y={} z={}",
-                baseline_mag.x, baseline_mag.y, baseline_mag.z
-            );
-
-            // Step 4: All motors at 50%
-            info!("Step 4: Motor interference at 50% (all motors)");
-            event::raise_event(event::Events::CalibrationStatus {
-                header: None,
-                line1: status_text("Mag interference"),
-                line2: status_text("All motors 50%"),
-                line3: status_text("Measuring 6s..."),
-            })
-            .await;
-
-            motor_driver::send_motor_command(MotorCommand::SetTrack {
-                track: Track::Left,
-                speed: 50,
-            })
-            .await;
-            motor_driver::send_motor_command(MotorCommand::SetTrack {
-                track: Track::Right,
-                speed: 50,
-            })
-            .await;
-            Timer::after(Duration::from_millis(1000)).await; // Let stabilize
-            clear_mag_measurement().await;
-            Timer::after(Duration::from_millis(500)).await; // Wait for fresh data
-            let mag_all_50 = measure_mag_average(500).await;
-            let interference_all_50 = subtract_mag(mag_all_50, baseline_mag);
-            info!(
-                "  All 50% interference: x={} y={} z={}",
-                interference_all_50.x, interference_all_50.y, interference_all_50.z
-            );
-
-            motor_driver::send_motor_command(MotorCommand::CoastAll).await;
-            Timer::after(Duration::from_millis(500)).await;
-
-            // Step 5: All motors at 100%
-            info!("Step 5: Motor interference at 100% (all motors)");
-            event::raise_event(event::Events::CalibrationStatus {
-                header: None,
-                line1: status_text("Mag interference"),
-                line2: status_text("All motors 100%"),
-                line3: status_text("Measuring 6s..."),
-            })
-            .await;
-
-            motor_driver::send_motor_command(MotorCommand::SetTrack {
-                track: Track::Left,
-                speed: 100,
-            })
-            .await;
-            motor_driver::send_motor_command(MotorCommand::SetTrack {
-                track: Track::Right,
-                speed: 100,
-            })
-            .await;
-            Timer::after(Duration::from_millis(1000)).await;
-            clear_mag_measurement().await;
-            Timer::after(Duration::from_millis(500)).await;
-            let mag_all_100 = measure_mag_average(500).await;
-            let interference_all_100 = subtract_mag(mag_all_100, baseline_mag);
-            info!(
-                "  All 100% interference: x={} y={} z={}",
-                interference_all_100.x, interference_all_100.y, interference_all_100.z
-            );
-
-            motor_driver::send_motor_command(MotorCommand::CoastAll).await;
-            Timer::after(Duration::from_millis(500)).await;
-
-            // Step 6: Left track at 50%
-            info!("Step 6: Motor interference at 50% (left track only)");
-            event::raise_event(event::Events::CalibrationStatus {
-                header: None,
-                line1: status_text("Mag interference"),
-                line2: status_text("Left track 50%"),
-                line3: status_text("Measuring 6s..."),
-            })
-            .await;
-
-            motor_driver::send_motor_command(MotorCommand::SetTrack {
-                track: Track::Left,
-                speed: 50,
-            })
-            .await;
-            motor_driver::send_motor_command(MotorCommand::SetTrack {
-                track: Track::Right,
-                speed: 0,
-            })
-            .await;
-            Timer::after(Duration::from_millis(1000)).await;
-            clear_mag_measurement().await;
-            Timer::after(Duration::from_millis(500)).await;
-            let mag_left_50 = measure_mag_average(500).await;
-            let interference_left_50 = subtract_mag(mag_left_50, baseline_mag);
-            info!(
-                "  Left 50% interference: x={} y={} z={}",
-                interference_left_50.x, interference_left_50.y, interference_left_50.z
-            );
-
-            motor_driver::send_motor_command(MotorCommand::CoastAll).await;
-            Timer::after(Duration::from_millis(500)).await;
-
-            // Step 7: Left track at 100%
-            info!("Step 7: Motor interference at 100% (left track only)");
-            event::raise_event(event::Events::CalibrationStatus {
-                header: None,
-                line1: status_text("Mag interference"),
-                line2: status_text("Left track 100%"),
-                line3: status_text("Measuring 6s..."),
-            })
-            .await;
-
-            motor_driver::send_motor_command(MotorCommand::SetTrack {
-                track: Track::Left,
-                speed: 100,
-            })
-            .await;
-            motor_driver::send_motor_command(MotorCommand::SetTrack {
-                track: Track::Right,
-                speed: 0,
-            })
-            .await;
-            Timer::after(Duration::from_millis(1000)).await;
-            clear_mag_measurement().await;
-            Timer::after(Duration::from_millis(500)).await;
-            let mag_left_100 = measure_mag_average(500).await;
-            let interference_left_100 = subtract_mag(mag_left_100, baseline_mag);
-            info!(
-                "  Left 100% interference: x={} y={} z={}",
-                interference_left_100.x, interference_left_100.y, interference_left_100.z
-            );
-
-            motor_driver::send_motor_command(MotorCommand::CoastAll).await;
-            Timer::after(Duration::from_millis(500)).await;
-
-            // Step 8: Right track at 50%
-            info!("Step 8: Motor interference at 50% (right track only)");
-            event::raise_event(event::Events::CalibrationStatus {
-                header: None,
-                line1: status_text("Mag interference"),
-                line2: status_text("Right track 50%"),
-                line3: status_text("Measuring 6s..."),
-            })
-            .await;
-
-            motor_driver::send_motor_command(MotorCommand::SetTrack {
-                track: Track::Left,
-                speed: 0,
-            })
-            .await;
-            motor_driver::send_motor_command(MotorCommand::SetTrack {
-                track: Track::Right,
-                speed: 50,
-            })
-            .await;
-            Timer::after(Duration::from_millis(1000)).await;
-            clear_mag_measurement().await;
-            Timer::after(Duration::from_millis(500)).await;
-            let mag_right_50 = measure_mag_average(500).await;
-            let interference_right_50 = subtract_mag(mag_right_50, baseline_mag);
-            info!(
-                "  Right 50% interference: x={} y={} z={}",
-                interference_right_50.x, interference_right_50.y, interference_right_50.z
-            );
-
-            motor_driver::send_motor_command(MotorCommand::CoastAll).await;
-            Timer::after(Duration::from_millis(500)).await;
-
-            // Step 9: Right track at 100%
-            info!("Step 9: Motor interference at 100% (right track only)");
-            event::raise_event(event::Events::CalibrationStatus {
-                header: None,
-                line1: status_text("Mag interference"),
-                line2: status_text("Right track 100%"),
-                line3: status_text("Measuring 6s..."),
-            })
-            .await;
-
-            motor_driver::send_motor_command(MotorCommand::SetTrack {
-                track: Track::Left,
-                speed: 0,
-            })
-            .await;
-            motor_driver::send_motor_command(MotorCommand::SetTrack {
-                track: Track::Right,
-                speed: 100,
-            })
-            .await;
-            Timer::after(Duration::from_millis(1000)).await;
-            clear_mag_measurement().await;
-            Timer::after(Duration::from_millis(500)).await;
-            let mag_right_100 = measure_mag_average(500).await;
-            let interference_right_100 = subtract_mag(mag_right_100, baseline_mag);
-            info!(
-                "  Right 100% interference: x={} y={} z={}",
-                interference_right_100.x, interference_right_100.y, interference_right_100.z
-            );
-
-            motor_driver::send_motor_command(MotorCommand::CoastAll).await;
-            Timer::after(Duration::from_millis(500)).await;
-
-            mag_x_interference_50 = [interference_all_50.x, interference_left_50.x, interference_right_50.x];
-            mag_y_interference_50 = [interference_all_50.y, interference_left_50.y, interference_right_50.y];
-            mag_z_interference_50 = [interference_all_50.z, interference_left_50.z, interference_right_50.z];
-            mag_x_interference_100 = [
-                interference_all_100.x,
-                interference_left_100.x,
-                interference_right_100.x,
-            ];
-            mag_y_interference_100 = [
-                interference_all_100.y,
-                interference_left_100.y,
-                interference_right_100.y,
-            ];
-            mag_z_interference_100 = [
-                interference_all_100.z,
-                interference_left_100.z,
-                interference_right_100.z,
-            ];
-            mag_completed = true;
-        }
-    }
-
-    // Step 10: Build calibration struct
-    info!("Step 10: Building complete calibration data structure");
-    let (line1, line2) = (status_text("Finalizing"), None);
-    event::raise_event(event::Events::CalibrationStatus {
-        header: None,
-        line1,
-        line2,
-        line3: None,
-    })
-    .await;
-    let imu_calibration = flash_storage::ImuCalibration {
-        gyro_x_bias,
-        gyro_y_bias,
-        gyro_z_bias,
-        accel_x_bias,
-        accel_y_bias,
-        accel_z_bias,
-        mag_x_bias,
-        mag_y_bias,
-        mag_z_bias,
-        mag_x_interference_50,
-        mag_y_interference_50,
-        mag_z_interference_50,
-        mag_x_interference_100,
-        mag_y_interference_100,
-        mag_z_interference_100,
-    };
-
-    // Save to flash
-    info!("Saving complete calibration to flash");
+    info!("Saving gyro calibration to flash");
     info!("╔═══════════════════════════════════════════════════╗");
-    info!("║        FINAL CALIBRATION SUMMARY                 ║");
+    info!("║     FINAL CALIBRATION SUMMARY (GYRO)             ║");
     info!("╠═══════════════════════════════════════════════════╣");
     info!("║  Gyro bias (deg/s):                              ║");
-    info!("║    X: {} Y: {} Z: {}", gyro_x_bias, gyro_y_bias, gyro_z_bias);
-    info!("║  Accel bias (g):                                 ║");
-    info!("║    X: {} Y: {} Z: {}", accel_x_bias, accel_y_bias, accel_z_bias);
-    info!("║  Magnetometer hard iron bias (μT):               ║");
-    info!("║    X: {} Y: {} Z: {}", mag_x_bias, mag_y_bias, mag_z_bias);
-    info!("║  Motor interference patterns captured ✓          ║");
+    info!(
+        "║    X: {} Y: {} Z: {}",
+        imu_calibration.gyro_x_bias, imu_calibration.gyro_y_bias, imu_calibration.gyro_z_bias
+    );
     info!("╚═══════════════════════════════════════════════════╝");
+
     event::raise_event(event::Events::CalibrationStatus {
         header: None,
         line1: status_text("Complete!"),
@@ -644,30 +697,17 @@ pub async fn run_imu_calibration(kind: ImuCalibrationKind) {
     })
     .await;
 
-    if run_gyro {
-        imu_flags.gyro = true;
-    }
-    if run_accel {
-        imu_flags.accel = true;
-    }
-    if mag_completed {
-        imu_flags.mag = true;
-    }
-
     flash_storage::send_flash_command(flash_storage::FlashCommand::SaveData(
         flash_storage::CalibrationDataKind::Imu(imu_calibration),
     ))
     .await;
     flash_storage::send_flash_command(flash_storage::FlashCommand::SaveImuFlags(imu_flags)).await;
 
-    // Brief delay to allow flash operation to complete
     Timer::after(Duration::from_millis(500)).await;
 
-    // Apply to IMU task immediately
-    info!("Applying calibration to IMU task");
+    info!("Applying gyro calibration to IMU task");
     imu_read::load_imu_calibration(imu_calibration);
 
-    // Display completion
     event::raise_event(event::Events::CalibrationStatus {
         header: None,
         line1: status_text("Complete!"),
@@ -677,8 +717,188 @@ pub async fn run_imu_calibration(kind: ImuCalibrationKind) {
     .await;
 
     event::raise_event(event::Events::CalibrationCompleted).await;
-
     Timer::after(Duration::from_secs(2)).await;
 
-    info!("=== IMU Calibration Complete ===");
+    info!("=== IMU Gyro Calibration Complete ===");
+}
+
+#[allow(clippy::too_many_lines)]
+#[allow(clippy::similar_names)]
+#[allow(clippy::cast_precision_loss)]
+/// Calibrate the accelerometer and persist results.
+async fn run_accel_calibration() {
+    use crate::{
+        system::event,
+        task::{io::flash_storage, sensors::imu as imu_read},
+    };
+
+    info!("=== Starting IMU Accel Calibration ===");
+
+    event::raise_event(event::Events::CalibrationStatus {
+        header: status_text("IMU Calibration"),
+        line1: status_text("Initializing"),
+        line2: None,
+        line3: None,
+    })
+    .await;
+
+    imu_read::start_imu_readings();
+    Timer::after(Duration::from_millis(500)).await;
+
+    let cached_calibration = flash_storage::get_cached_imu_calibration().await.unwrap_or_default();
+    let mut imu_calibration = cached_calibration;
+    let mut imu_flags = flash_storage::get_cached_imu_flags().await.unwrap_or_default();
+
+    let (_, accel_bias) = run_gyro_accel_calibration(false, true).await;
+    imu_calibration.accel_x_bias = accel_bias.x;
+    imu_calibration.accel_y_bias = accel_bias.y;
+    imu_calibration.accel_z_bias = accel_bias.z;
+    imu_flags.accel = true;
+
+    info!("Saving accel calibration to flash");
+    info!("╔═══════════════════════════════════════════════════╗");
+    info!("║    FINAL CALIBRATION SUMMARY (ACCEL)             ║");
+    info!("╠═══════════════════════════════════════════════════╣");
+    info!("║  Accel bias (g):                                 ║");
+    info!(
+        "║    X: {} Y: {} Z: {}",
+        imu_calibration.accel_x_bias, imu_calibration.accel_y_bias, imu_calibration.accel_z_bias
+    );
+    info!("╚═══════════════════════════════════════════════════╝");
+
+    event::raise_event(event::Events::CalibrationStatus {
+        header: None,
+        line1: status_text("Complete!"),
+        line2: status_text("Saving to flash"),
+        line3: status_text("Please wait"),
+    })
+    .await;
+
+    flash_storage::send_flash_command(flash_storage::FlashCommand::SaveData(
+        flash_storage::CalibrationDataKind::Imu(imu_calibration),
+    ))
+    .await;
+    flash_storage::send_flash_command(flash_storage::FlashCommand::SaveImuFlags(imu_flags)).await;
+
+    Timer::after(Duration::from_millis(500)).await;
+
+    info!("Applying accel calibration to IMU task");
+    imu_read::load_imu_calibration(imu_calibration);
+
+    event::raise_event(event::Events::CalibrationStatus {
+        header: None,
+        line1: status_text("Complete!"),
+        line2: status_text("Calibration saved"),
+        line3: None,
+    })
+    .await;
+
+    event::raise_event(event::Events::CalibrationCompleted).await;
+    Timer::after(Duration::from_secs(2)).await;
+
+    info!("=== IMU Accel Calibration Complete ===");
+}
+
+#[allow(clippy::too_many_lines)]
+#[allow(clippy::similar_names)]
+#[allow(clippy::cast_precision_loss)]
+/// Calibrate the magnetometer and persist results.
+async fn run_mag_calibration() {
+    use crate::{
+        system::event,
+        task::{io::flash_storage, sensors::imu as imu_read},
+    };
+
+    info!("=== Starting IMU Mag Calibration ===");
+
+    event::raise_event(event::Events::CalibrationStatus {
+        header: status_text("IMU Calibration"),
+        line1: status_text("Initializing"),
+        line2: None,
+        line3: None,
+    })
+    .await;
+
+    imu_read::start_imu_readings();
+    Timer::after(Duration::from_millis(500)).await;
+
+    let cached_calibration = flash_storage::get_cached_imu_calibration().await.unwrap_or_default();
+    let mut imu_calibration = cached_calibration;
+    let mut imu_flags = flash_storage::get_cached_imu_flags().await.unwrap_or_default();
+
+    if let Some(mag_result) = run_mag_calibration_steps(MAG_CALIBRATION_CONFIG).await {
+        imu_calibration.mag_x_bias = mag_result.bias.x;
+        imu_calibration.mag_y_bias = mag_result.bias.y;
+        imu_calibration.mag_z_bias = mag_result.bias.z;
+        imu_calibration.mag_x_scale = mag_result.scale.x;
+        imu_calibration.mag_y_scale = mag_result.scale.y;
+        imu_calibration.mag_z_scale = mag_result.scale.z;
+        imu_calibration.mag_x_interference_50 = mag_result.interference.x_50;
+        imu_calibration.mag_y_interference_50 = mag_result.interference.y_50;
+        imu_calibration.mag_z_interference_50 = mag_result.interference.z_50;
+        imu_calibration.mag_x_interference_100 = mag_result.interference.x_100;
+        imu_calibration.mag_y_interference_100 = mag_result.interference.y_100;
+        imu_calibration.mag_z_interference_100 = mag_result.interference.z_100;
+        imu_flags.mag = true;
+    } else {
+        info!("Mag calibration failed; keeping previous values");
+    }
+
+    info!("Saving mag calibration to flash");
+    info!("╔═══════════════════════════════════════════════════╗");
+    info!("║     FINAL CALIBRATION SUMMARY (MAG)              ║");
+    info!("╠═══════════════════════════════════════════════════╣");
+    info!("║  Magnetometer hard iron bias (μT):               ║");
+    info!(
+        "║    X: {} Y: {} Z: {}",
+        imu_calibration.mag_x_bias, imu_calibration.mag_y_bias, imu_calibration.mag_z_bias
+    );
+    info!("║  Magnetometer soft iron scale:                   ║");
+    info!(
+        "║    X: {} Y: {} Z: {}",
+        imu_calibration.mag_x_scale, imu_calibration.mag_y_scale, imu_calibration.mag_z_scale
+    );
+    info!("║  Motor interference patterns captured ✓          ║");
+    info!("╚═══════════════════════════════════════════════════╝");
+
+    event::raise_event(event::Events::CalibrationStatus {
+        header: None,
+        line1: status_text("Complete!"),
+        line2: status_text("Saving to flash"),
+        line3: status_text("Please wait"),
+    })
+    .await;
+
+    flash_storage::send_flash_command(flash_storage::FlashCommand::SaveData(
+        flash_storage::CalibrationDataKind::Imu(imu_calibration),
+    ))
+    .await;
+    flash_storage::send_flash_command(flash_storage::FlashCommand::SaveImuFlags(imu_flags)).await;
+
+    Timer::after(Duration::from_millis(500)).await;
+
+    info!("Applying mag calibration to IMU task");
+    imu_read::load_imu_calibration(imu_calibration);
+
+    event::raise_event(event::Events::CalibrationStatus {
+        header: None,
+        line1: status_text("Complete!"),
+        line2: status_text("Calibration saved"),
+        line3: None,
+    })
+    .await;
+
+    event::raise_event(event::Events::CalibrationCompleted).await;
+    Timer::after(Duration::from_secs(2)).await;
+
+    info!("=== IMU Mag Calibration Complete ===");
+}
+
+/// Dispatch the requested IMU calibration routine.
+pub async fn run_imu_calibration(kind: ImuCalibrationKind) {
+    match kind {
+        ImuCalibrationKind::Gyro => run_gyro_calibration().await,
+        ImuCalibrationKind::Accel => run_accel_calibration().await,
+        ImuCalibrationKind::Mag => run_mag_calibration().await,
+    }
 }

--- a/src/task/drive/calibration/imu.rs
+++ b/src/task/drive/calibration/imu.rs
@@ -65,6 +65,43 @@ const MAG_CALIBRATION_CONFIG: MagCalibrationConfig = MagCalibrationConfig {
 /// Must be comfortably above the IMU sampling period (~20.4 ms at 48.9 Hz).
 const GYRO_ACCEL_SAMPLE_TIMEOUT: Duration = Duration::from_millis(30);
 
+/// Ensures IMU readings are stopped (and fusion mode restored) after calibration completes.
+struct ImuReadingsGuard {
+    /// Fusion mode to restore after calibration (if any).
+    restore_fusion_mode: Option<crate::task::sensors::imu::AhrsFusionMode>,
+}
+
+impl ImuReadingsGuard {
+    /// Start IMU readings without changing fusion mode.
+    fn start() -> Self {
+        crate::task::sensors::imu::start_imu_readings();
+        Self {
+            restore_fusion_mode: None,
+        }
+    }
+
+    /// Start IMU readings and set a temporary fusion mode.
+    fn start_with_fusion_mode(
+        target_mode: crate::task::sensors::imu::AhrsFusionMode,
+        restore_mode: crate::task::sensors::imu::AhrsFusionMode,
+    ) -> Self {
+        crate::task::sensors::imu::start_imu_readings();
+        crate::task::sensors::imu::set_ahrs_fusion_mode(target_mode);
+        Self {
+            restore_fusion_mode: Some(restore_mode),
+        }
+    }
+}
+
+impl Drop for ImuReadingsGuard {
+    fn drop(&mut self) {
+        if let Some(mode) = self.restore_fusion_mode {
+            crate::task::sensors::imu::set_ahrs_fusion_mode(mode);
+        }
+        crate::task::sensors::imu::stop_imu_readings();
+    }
+}
+
 #[derive(Copy, Clone)]
 /// Motor command step used to measure or verify mag interference.
 struct InterferenceStep {
@@ -1017,7 +1054,7 @@ async fn run_gyro_calibration() {
     })
     .await;
 
-    imu_read::start_imu_readings();
+    let _imu_guard = ImuReadingsGuard::start();
     Timer::after(Duration::from_millis(500)).await;
 
     let cached_calibration = flash_storage::get_cached_imu_calibration().await.unwrap_or_default();
@@ -1110,7 +1147,7 @@ async fn run_accel_calibration() {
     })
     .await;
 
-    imu_read::start_imu_readings();
+    let _imu_guard = ImuReadingsGuard::start();
     Timer::after(Duration::from_millis(500)).await;
 
     let cached_calibration = flash_storage::get_cached_imu_calibration().await.unwrap_or_default();
@@ -1203,7 +1240,8 @@ async fn run_mag_calibration() {
     })
     .await;
 
-    imu_read::start_imu_readings();
+    let _imu_guard =
+        ImuReadingsGuard::start_with_fusion_mode(imu_read::AhrsFusionMode::Axis9, imu_read::DEFAULT_FUSION_MODE);
     Timer::after(Duration::from_millis(500)).await;
 
     let cached_calibration = flash_storage::get_cached_imu_calibration().await.unwrap_or_default();

--- a/src/task/drive/calibration/imu.rs
+++ b/src/task/drive/calibration/imu.rs
@@ -244,8 +244,16 @@ struct MagCalibrationResult {
     interference: InterferenceData,
 }
 
+/// Gyro/accel calibration output with optional biases.
+struct GyroAccelCalibrationResult {
+    /// Gyro bias if enough samples were captured.
+    gyro_bias: Option<Vector3<f32>>,
+    /// Accel bias if enough samples were captured.
+    accel_bias: Option<Vector3<f32>>,
+}
+
 /// Collect stationary samples and compute gyro/accel bias vectors.
-async fn run_gyro_accel_calibration(run_gyro: bool, run_accel: bool) -> (Vector3<f32>, Vector3<f32>) {
+async fn run_gyro_accel_calibration(run_gyro: bool, run_accel: bool) -> GyroAccelCalibrationResult {
     use crate::system::event;
 
     let step_label = if run_gyro && run_accel {
@@ -268,23 +276,21 @@ async fn run_gyro_accel_calibration(run_gyro: bool, run_accel: bool) -> (Vector3
     info!("  Collecting calibration samples (stationary)...");
     let mut gyro_sum = Vector3::new(0.0f32, 0.0f32, 0.0f32);
     let mut accel_sum = Vector3::new(0.0f32, 0.0f32, 0.0f32);
+    let mut gyro_samples: u16 = 0;
+    let mut accel_samples: u16 = 0;
     let num_samples: u16 = 500; // 500 samples at 50Hz = 10 seconds
-    let num_samples_f32 = f32::from(num_samples);
+    let min_samples = (num_samples * 8) / 10;
 
-    if run_gyro {
-        clear_gyro_measurement().await;
-    }
-    if run_accel {
-        clear_accel_measurement().await;
-    }
     Timer::after(Duration::from_millis(100)).await;
 
     for i in 0..num_samples {
         if run_gyro {
+            clear_gyro_measurement().await;
             let start = embassy_time::Instant::now();
             while embassy_time::Instant::now().duration_since(start).as_millis() < 20 {
                 if let Some(gyro_data) = get_latest_gyro_measurement().await {
                     gyro_sum += gyro_data;
+                    gyro_samples += 1;
                     break;
                 }
                 Timer::after(Duration::from_millis(1)).await;
@@ -292,10 +298,12 @@ async fn run_gyro_accel_calibration(run_gyro: bool, run_accel: bool) -> (Vector3
         }
 
         if run_accel {
+            clear_accel_measurement().await;
             let start = embassy_time::Instant::now();
             while embassy_time::Instant::now().duration_since(start).as_millis() < 20 {
                 if let Some(accel_data) = get_latest_accel_measurement().await {
                     accel_sum += accel_data;
+                    accel_samples += 1;
                     break;
                 }
                 Timer::after(Duration::from_millis(1)).await;
@@ -316,34 +324,45 @@ async fn run_gyro_accel_calibration(run_gyro: bool, run_accel: bool) -> (Vector3
         }
     }
 
-    let computed_gyro_bias = if run_gyro {
-        gyro_sum / num_samples_f32
+    if (run_gyro && gyro_samples < min_samples) || (run_accel && accel_samples < min_samples) {
+        info!(
+            "Calibration sample shortfall (gyro={}/{} accel={}/{})",
+            gyro_samples, num_samples, accel_samples, num_samples
+        );
+    }
+
+    let gyro_bias = if run_gyro && gyro_samples >= min_samples && gyro_samples > 0 {
+        Some(gyro_sum / f32::from(gyro_samples))
     } else {
-        Vector3::new(0.0, 0.0, 0.0)
+        None
     };
-    let computed_accel_bias = if run_accel {
-        let mut bias = accel_sum / num_samples_f32;
+    let accel_bias = if run_accel && accel_samples >= min_samples && accel_samples > 0 {
+        let mut bias = accel_sum / f32::from(accel_samples);
         bias.z -= 1.0;
-        bias
+        Some(bias)
     } else {
-        Vector3::new(0.0, 0.0, 0.0)
+        None
     };
 
-    if run_gyro {
+    if let Some(bias) = gyro_bias {
         info!("  ✓ Gyro bias calculated:");
-        info!("    X: {} deg/s", computed_gyro_bias.x);
-        info!("    Y: {} deg/s", computed_gyro_bias.y);
-        info!("    Z: {} deg/s", computed_gyro_bias.z);
+        info!("    X: {} deg/s", bias.x);
+        info!("    Y: {} deg/s", bias.y);
+        info!("    Z: {} deg/s", bias.z);
+    } else if run_gyro {
+        info!("  ! Gyro calibration failed (insufficient samples)");
     }
 
-    if run_accel {
+    if let Some(bias) = accel_bias {
         info!("  ✓ Accel bias calculated:");
-        info!("    X: {} g", computed_accel_bias.x);
-        info!("    Y: {} g", computed_accel_bias.y);
-        info!("    Z: {} g (gravity removed)", computed_accel_bias.z);
+        info!("    X: {} g", bias.x);
+        info!("    Y: {} g", bias.y);
+        info!("    Z: {} g (gravity removed)", bias.z);
+    } else if run_accel {
+        info!("  ! Accel calibration failed (insufficient samples)");
     }
 
-    (computed_gyro_bias, computed_accel_bias)
+    GyroAccelCalibrationResult { gyro_bias, accel_bias }
 }
 
 /// Gather magnetometer samples until coverage and sample thresholds are met.
@@ -672,7 +691,23 @@ async fn run_gyro_calibration() {
     let mut imu_calibration = cached_calibration;
     let mut imu_flags = flash_storage::get_cached_imu_flags().await.unwrap_or_default();
 
-    let (gyro_bias, _) = run_gyro_accel_calibration(true, false).await;
+    let result = run_gyro_accel_calibration(true, false).await;
+    let Some(gyro_bias) = result.gyro_bias else {
+        info!("Gyro calibration failed; keeping previous values");
+        event::raise_event(event::Events::CalibrationStatus {
+            header: None,
+            line1: status_text("GYRO FAILED"),
+            line2: status_text("Not saved"),
+            line3: None,
+        })
+        .await;
+        event::raise_event(event::Events::CalibrationCompleted).await;
+        Timer::after(Duration::from_secs(2)).await;
+
+        info!("=== IMU Gyro Calibration Complete ===");
+        return;
+    };
+
     imu_calibration.gyro_x_bias = gyro_bias.x;
     imu_calibration.gyro_y_bias = gyro_bias.y;
     imu_calibration.gyro_z_bias = gyro_bias.z;
@@ -749,7 +784,23 @@ async fn run_accel_calibration() {
     let mut imu_calibration = cached_calibration;
     let mut imu_flags = flash_storage::get_cached_imu_flags().await.unwrap_or_default();
 
-    let (_, accel_bias) = run_gyro_accel_calibration(false, true).await;
+    let result = run_gyro_accel_calibration(false, true).await;
+    let Some(accel_bias) = result.accel_bias else {
+        info!("Accel calibration failed; keeping previous values");
+        event::raise_event(event::Events::CalibrationStatus {
+            header: None,
+            line1: status_text("ACCEL FAILED"),
+            line2: status_text("Not saved"),
+            line3: None,
+        })
+        .await;
+        event::raise_event(event::Events::CalibrationCompleted).await;
+        Timer::after(Duration::from_secs(2)).await;
+
+        info!("=== IMU Accel Calibration Complete ===");
+        return;
+    };
+
     imu_calibration.accel_x_bias = accel_bias.x;
     imu_calibration.accel_y_bias = accel_bias.y;
     imu_calibration.accel_z_bias = accel_bias.z;

--- a/src/task/drive/mod.rs
+++ b/src/task/drive/mod.rs
@@ -119,8 +119,7 @@ use intent::{
     step_idle_without_drift,
 };
 pub use sensors::data::{
-    clear_encoder_measurement, get_latest_accel_measurement, get_latest_encoder_measurement,
-    get_latest_gyro_measurement, get_latest_mag_measurement, send_accel_measurement, send_gyro_measurement,
+    clear_encoder_measurement, get_latest_encoder_measurement, send_accel_measurement, send_gyro_measurement,
     send_mag_measurement, try_send_encoder_measurement, try_send_imu_measurement,
 };
 use state::DriveLoop;

--- a/src/task/drive/mod.rs
+++ b/src/task/drive/mod.rs
@@ -136,7 +136,7 @@ pub use types::{
 /// This is a high-level control task that:
 /// - Receives drive commands via queue.
 /// - Receives encoder feedback via channel (from orchestrator).
-/// - Receives IMU feedback via channel (from orchestrator).
+/// - Receives IMU feedback via channel (from orchestrator); orientation is calibrated when the IMU task has loaded calibration data.
 /// - Receives interrupts via signal.
 /// - Sends motor commands to the `motor_driver` task.
 /// - Coordinates calibration procedures.

--- a/src/task/drive/sensors/control.rs
+++ b/src/task/drive/sensors/control.rs
@@ -25,7 +25,7 @@ use crate::{
         drive::types,
         sensors::{
             encoders::{self as encoder_read},
-            imu::{self, AhrsFusionMode},
+            imu::{self, DEFAULT_FUSION_MODE},
         },
     },
 };
@@ -46,7 +46,7 @@ pub async fn stop_rotation_imu() {
 /// to correct heading drift during curved motion.
 pub async fn start_curve_imu(kind: &types::DriveDistanceKind) {
     if matches!(kind, types::DriveDistanceKind::CurveArc { .. }) {
-        imu::set_ahrs_fusion_mode(AhrsFusionMode::Axis9);
+        imu::set_ahrs_fusion_mode(DEFAULT_FUSION_MODE);
         raise_event(Events::StartStopMotionDataCollection(true)).await;
     }
 }

--- a/src/task/drive/sensors/data.rs
+++ b/src/task/drive/sensors/data.rs
@@ -10,10 +10,11 @@
 //! - **Encoder measurements** are stored in a mutex-guarded `Option` so the
 //!   drive task always reads the latest value rather than draining a queue.
 //! - **IMU measurements** are queued (capacity 16) to buffer bursts during
-//!   calibration sequences at 100 Hz sampling.
+//!   calibration sequences at 50 Hz sampling. These measurements carry
+//!   calibrated orientation when the IMU task has loaded calibration data.
 //! - **Raw IMU axes** (magnetometer, gyroscope, accelerometer) are stored as
-//!   mutex-guarded `Option`s, written by the IMU task and read by calibration
-//!   routines on demand.
+//!   mutex-guarded `Option`s, written by the IMU task before correction and
+//!   read by calibration routines on demand.
 //!
 //! # Visibility
 //!
@@ -40,11 +41,12 @@ pub static LATEST_ENCODER_MEASUREMENT: Mutex<CriticalSectionRawMutex, Option<Enc
 
 /// Channel for receiving IMU measurements from the orchestrator.
 ///
-/// Capacity of 16 buffers bursts during calibration sequences at 100 Hz
+/// Capacity of 16 buffers bursts during calibration sequences at 50 Hz
 /// sampling. The rotation control loop drains this channel each tick.
 const IMU_FEEDBACK_QUEUE_SIZE: usize = 16;
 
 /// IMU feedback channel shared between the orchestrator and drive control loops.
+/// Measurements carry orientation already corrected by any loaded IMU calibration.
 pub static IMU_FEEDBACK_CHANNEL: Channel<CriticalSectionRawMutex, ImuMeasurement, IMU_FEEDBACK_QUEUE_SIZE> =
     Channel::new();
 
@@ -83,8 +85,9 @@ pub fn try_send_encoder_measurement(measurement: EncoderMeasurement) -> bool {
 /// Try to send an IMU measurement to the drive task without blocking.
 ///
 /// Returns `true` if sent, `false` if the channel is full. Used by the
-/// orchestrator to avoid blocking; IMU measurements arrive at 100 Hz so
-/// dropping occasional readings during heavy load is acceptable.
+/// orchestrator to avoid blocking; IMU measurements arrive at 50 Hz so
+/// dropping occasional readings during heavy load is acceptable. The
+/// orientation data is calibrated when the IMU task has loaded calibration.
 pub fn try_send_imu_measurement(measurement: ImuMeasurement) -> bool {
     IMU_FEEDBACK_CHANNEL.sender().try_send(measurement).is_ok()
 }
@@ -198,11 +201,11 @@ pub async fn measure_mag_average(samples: u16) -> Vector3<f32> {
     let mut count = 0u16;
 
     for _ in 0..samples {
-        if let Some(mag) = get_latest_mag_measurement().await {
+        clear_mag_measurement().await;
+        if let Some(mag) = wait_for_mag_event_timeout(50).await {
             sum += mag.cast::<f64>();
             count += 1;
         }
-        Timer::after(Duration::from_millis(20)).await; // ~50 Hz
     }
 
     if count > 0 {

--- a/src/task/io/flash_storage.rs
+++ b/src/task/io/flash_storage.rs
@@ -103,26 +103,33 @@ pub enum FlashCommand {
 /// IMU calibration data structure
 #[derive(Debug, Clone, Copy, Format)]
 pub struct ImuCalibration {
-    /// Gyroscope X-axis bias (rad/s)
+    /// Gyroscope X-axis bias (deg/s)
     pub gyro_x_bias: f32,
-    /// Gyroscope Y-axis bias (rad/s)
+    /// Gyroscope Y-axis bias (deg/s)
     pub gyro_y_bias: f32,
-    /// Gyroscope Z-axis bias (rad/s)
+    /// Gyroscope Z-axis bias (deg/s)
     pub gyro_z_bias: f32,
 
-    /// Accelerometer X-axis bias (m/s²)
+    /// Accelerometer X-axis bias (g)
     pub accel_x_bias: f32,
-    /// Accelerometer Y-axis bias (m/s²)
+    /// Accelerometer Y-axis bias (g)
     pub accel_y_bias: f32,
-    /// Accelerometer Z-axis bias (m/s²)
+    /// Accelerometer Z-axis bias (g)
     pub accel_z_bias: f32,
 
-    /// Magnetometer X-axis bias
+    /// Magnetometer X-axis bias (μT)
     pub mag_x_bias: f32,
-    /// Magnetometer Y-axis bias
+    /// Magnetometer Y-axis bias (μT)
     pub mag_y_bias: f32,
-    /// Magnetometer Z-axis bias
+    /// Magnetometer Z-axis bias (μT)
     pub mag_z_bias: f32,
+
+    /// Magnetometer soft-iron scale (unitless)
+    pub mag_x_scale: f32,
+    /// Magnetometer soft-iron scale (unitless)
+    pub mag_y_scale: f32,
+    /// Magnetometer soft-iron scale (unitless)
+    pub mag_z_scale: f32,
 
     /// x-Axis Motor interference correction factor at 50% power
     pub mag_x_interference_50: [f32; 3],
@@ -162,6 +169,9 @@ impl Default for ImuCalibration {
             mag_x_bias: 0.0,
             mag_y_bias: 0.0,
             mag_z_bias: 0.0,
+            mag_x_scale: 1.0,
+            mag_y_scale: 1.0,
+            mag_z_scale: 1.0,
             mag_x_interference_50: [0.0; 3],
             mag_y_interference_50: [0.0; 3],
             mag_z_interference_50: [0.0; 3],
@@ -252,7 +262,7 @@ impl Value<'_> for MotorCalibration {
 /// Serialize IMU calibration to bytes
 impl Value<'_> for ImuCalibration {
     fn serialize_into(&self, buffer: &mut [u8]) -> Result<usize, SerializationError> {
-        const REQUIRED_SIZE: usize = 108; // 27 floats * 4 bytes
+        const REQUIRED_SIZE: usize = 120; // 30 floats * 4 bytes
         if buffer.len() < REQUIRED_SIZE {
             return Err(SerializationError::BufferTooSmall);
         }
@@ -307,7 +317,15 @@ impl Value<'_> for ImuCalibration {
             offset += 4;
         }
 
-        Ok(108)
+        // Soft-iron scale (3 floats)
+        buffer[offset..offset + 4].copy_from_slice(&self.mag_x_scale.to_le_bytes());
+        offset += 4;
+        buffer[offset..offset + 4].copy_from_slice(&self.mag_y_scale.to_le_bytes());
+        offset += 4;
+        buffer[offset..offset + 4].copy_from_slice(&self.mag_z_scale.to_le_bytes());
+        offset += 4;
+
+        Ok(offset)
     }
 
     /// Deserialize IMU calibration from bytes
@@ -316,8 +334,9 @@ impl Value<'_> for ImuCalibration {
     where
         Self: Sized,
     {
-        const REQUIRED_SIZE: usize = 108; // 27 floats * 4 bytes
-        if buffer.len() < REQUIRED_SIZE {
+        const MIN_SIZE: usize = 108; // 27 floats * 4 bytes (legacy)
+        const SCALE_SIZE: usize = 12; // 3 floats * 4 bytes (soft-iron scale)
+        if buffer.len() < MIN_SIZE {
             return Err(SerializationError::BufferTooSmall);
         }
 
@@ -452,6 +471,35 @@ impl Value<'_> for ImuCalibration {
             offset += 4;
         }
 
+        let (mag_x_scale, mag_y_scale, mag_z_scale) = if buffer.len() >= MIN_SIZE + SCALE_SIZE {
+            let mag_x_scale = f32::from_le_bytes([
+                buffer[offset],
+                buffer[offset + 1],
+                buffer[offset + 2],
+                buffer[offset + 3],
+            ]);
+            offset += 4;
+            let mag_y_scale = f32::from_le_bytes([
+                buffer[offset],
+                buffer[offset + 1],
+                buffer[offset + 2],
+                buffer[offset + 3],
+            ]);
+            offset += 4;
+            let mag_z_scale = f32::from_le_bytes([
+                buffer[offset],
+                buffer[offset + 1],
+                buffer[offset + 2],
+                buffer[offset + 3],
+            ]);
+            offset += 4;
+            (mag_x_scale, mag_y_scale, mag_z_scale)
+        } else {
+            (1.0, 1.0, 1.0)
+        };
+
+        let consumed = offset;
+
         Ok((
             Self {
                 gyro_x_bias,
@@ -463,6 +511,9 @@ impl Value<'_> for ImuCalibration {
                 mag_x_bias,
                 mag_y_bias,
                 mag_z_bias,
+                mag_x_scale,
+                mag_y_scale,
+                mag_z_scale,
                 mag_x_interference_50,
                 mag_y_interference_50,
                 mag_z_interference_50,
@@ -470,7 +521,7 @@ impl Value<'_> for ImuCalibration {
                 mag_y_interference_100,
                 mag_z_interference_100,
             },
-            REQUIRED_SIZE,
+            consumed,
         ))
     }
 }
@@ -526,7 +577,7 @@ pub async fn flash_storage(flash: Flash<'static, embassy_rp::peripherals::FLASH,
     let mut storage = MapStorage::<StorageKey, _, _>::new(flash, MapConfig::new(flash_range.clone()), NoCache::new());
 
     // Create scratch buffer for serialization/deserialization
-    // Motor calibration needs 16 bytes, IMU calibration needs 108 bytes
+    // Motor calibration needs 16 bytes, IMU calibration needs 120 bytes
     // Using 128 bytes to be safe and align with common practice
     let mut data_buffer: [u8; 128] = [0; 128];
 

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -482,9 +482,8 @@ fn init_madgwick() -> Madgwick<f32> {
 }
 
 /// Check if magnetometer reading is within reasonable bounds to be considered valid for fusion
-fn should_use_magnetometer(mag_data: &Vector3<f32>) -> bool {
-    let mag_magnitude = mag_data.norm();
-    mag_magnitude > MAG_MIN_UT && mag_magnitude < MAG_MAX_UT
+fn should_use_magnetometer(mag_norm: f32) -> bool {
+    mag_norm > MAG_MIN_UT && mag_norm < MAG_MAX_UT
 }
 
 /// Logs magnetometer diagnostics for debugging yaw drift issues.
@@ -622,16 +621,16 @@ async fn prepare_magnetometer(
     // Lower bound: 20.0 μT rejects clearly invalid readings (below Earth's minimum)
     // Upper bound: 200.0 μT allows for magnetic interference while rejecting sensor errors
     let mag_norm = mag_data.norm();
-    let use_magnetometer = should_use_magnetometer(&mag_data);
+    let use_magnetometer = should_use_magnetometer(mag_norm);
+
+    // Low-rate magnetometer diagnostics to debug yaw "sticking" / magnetic issues.
+    // This is especially useful when validating hard/soft-iron calibration and interference correction.
+    log_mag_diagnostics(&mag_data, use_magnetometer);
 
     if use_magnetometer {
         let denom = mag_norm.max(1e-3);
         mag_data /= denom;
     }
-
-    // Low-rate magnetometer diagnostics to debug yaw "sticking" / magnetic issues.
-    // This is especially useful when validating hard/soft-iron calibration and interference correction.
-    log_mag_diagnostics(&mag_data, use_magnetometer);
 
     Ok((mag_data, use_magnetometer))
 }

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -338,6 +338,13 @@ fn apply_motor_interference_correction(
     mag_data.z -= interference.2;
 }
 
+/// Apply magnetometer bias and soft-iron scaling
+fn apply_mag_calibration(mag_data: &mut Vector3<f32>, calibration: &flash_storage::ImuCalibration) {
+    mag_data.x = (mag_data.x - calibration.mag_x_bias) * calibration.mag_x_scale;
+    mag_data.y = (mag_data.y - calibration.mag_y_bias) * calibration.mag_y_scale;
+    mag_data.z = (mag_data.z - calibration.mag_z_bias) * calibration.mag_z_scale;
+}
+
 /// Initialize the IMU sensor with retries
 async fn init_imu_sensor(i2c_bus: &'static I2cBusShared) -> ImuSensor {
     // On battery power-up, the IMU can still be in POR / internal regulator startup when
@@ -607,6 +614,7 @@ async fn prepare_magnetometer(
     if let Some(cal) = current_calibration {
         let (left_speed, right_speed) = motion::get_track_speeds_atomic();
         apply_motor_interference_correction(&mut mag_data, cal, left_speed, right_speed);
+        apply_mag_calibration(&mut mag_data, cal);
     }
 
     // Check if magnetometer reading is reasonable
@@ -616,7 +624,7 @@ async fn prepare_magnetometer(
     let use_magnetometer = should_use_magnetometer(&mag_data);
 
     // Low-rate magnetometer diagnostics to debug yaw "sticking" / magnetic issues.
-    // This is especially useful before hard/soft-iron calibration is implemented.
+    // This is especially useful when validating hard/soft-iron calibration and interference correction.
     log_mag_diagnostics(&mag_data, use_magnetometer);
 
     Ok((mag_data, use_magnetometer))
@@ -629,9 +637,6 @@ async fn sample_once(
     madgwick: &mut Madgwick<f32>,
     fusion_mode: AhrsFusionMode,
     current_calibration: Option<&flash_storage::ImuCalibration>,
-    gyro_bias_x: f32,
-    gyro_bias_y: f32,
-    gyro_bias_z: f32,
     accel_consecutive_failures: &mut u32,
     gyro_consecutive_failures: &mut u32,
     mag_consecutive_failures: &mut u32,
@@ -648,16 +653,27 @@ async fn sample_once(
         Err(outcome) => return outcome,
     };
 
-    let gyro_x = gyro_data.x - gyro_bias_x;
-    let gyro_y = gyro_data.y - gyro_bias_y;
-    let gyro_z = gyro_data.z - gyro_bias_z;
-
     // Send raw gyroscope reading to drive task for calibration purposes
     // (before bias correction is applied)
     drive::send_gyro_measurement(Vector3::new(gyro_data.x, gyro_data.y, gyro_data.z)).await;
 
     // Send raw accelerometer reading to drive task for calibration purposes
     drive::send_accel_measurement(accel_data).await;
+
+    let (gyro_bias_x, gyro_bias_y, gyro_bias_z) = current_calibration.map_or((0.0, 0.0, 0.0), |cal| {
+        (cal.gyro_x_bias, cal.gyro_y_bias, cal.gyro_z_bias)
+    });
+
+    let gyro_x = gyro_data.x - gyro_bias_x;
+    let gyro_y = gyro_data.y - gyro_bias_y;
+    let gyro_z = gyro_data.z - gyro_bias_z;
+
+    let mut accel_corrected = accel_data;
+    if let Some(cal) = current_calibration {
+        accel_corrected.x -= cal.accel_x_bias;
+        accel_corrected.y -= cal.accel_y_bias;
+        accel_corrected.z -= cal.accel_z_bias;
+    }
 
     // Convert gyroscope from degrees/s to radians/s for AHRS
     let gyro_rad = Vector3::new(gyro_x.to_radians(), gyro_y.to_radians(), gyro_z.to_radians());
@@ -667,7 +683,7 @@ async fn sample_once(
     let result = match fusion_mode {
         AhrsFusionMode::Axis6 => {
             // 6-axis fusion: gyro + accel (yaw will drift over time)
-            madgwick.update_imu(&gyro_rad, &accel_data)
+            madgwick.update_imu(&gyro_rad, &accel_corrected)
         }
         AhrsFusionMode::Axis9 => {
             let (mag_data, use_magnetometer) =
@@ -678,10 +694,10 @@ async fn sample_once(
 
             if use_magnetometer {
                 // 9-axis fusion: gyro + accel + mag (absolute heading, no yaw drift)
-                madgwick.update(&gyro_rad, &accel_data, &mag_data)
+                madgwick.update(&gyro_rad, &accel_corrected, &mag_data)
             } else {
                 // 6-axis fallback when mag is not trustworthy
-                madgwick.update_imu(&gyro_rad, &accel_data)
+                madgwick.update_imu(&gyro_rad, &accel_corrected)
             }
         }
     };
@@ -708,13 +724,7 @@ async fn sample_once(
 }
 
 /// Main command loop for handling IMU reading state and processing commands
-async fn run_imu_command_loop(
-    sensor: &mut ImuSensor,
-    madgwick: &mut Madgwick<f32>,
-    gyro_bias_x: f32,
-    gyro_bias_y: f32,
-    gyro_bias_z: f32,
-) {
+async fn run_imu_command_loop(sensor: &mut ImuSensor, madgwick: &mut Madgwick<f32>) {
     // Store current calibration data
     // Calibration will be loaded by orchestrator during initialization
     // and sent via LoadCalibration command
@@ -768,9 +778,6 @@ async fn run_imu_command_loop(
                                 madgwick,
                                 fusion_mode,
                                 current_calibration.as_ref(),
-                                gyro_bias_x,
-                                gyro_bias_y,
-                                gyro_bias_z,
                                 &mut accel_consecutive_failures,
                                 &mut gyro_consecutive_failures,
                                 &mut mag_consecutive_failures,
@@ -837,13 +844,7 @@ pub async fn inertial_measurement_read(i2c_bus: &'static I2cBusShared) {
 
     let mut madgwick = init_madgwick();
 
-    // TODO: Load gyroscope bias calibration values from flash memory
-    // For now, assume zero bias (will be implemented as dedicated calibration feature)
-    let gyro_bias_x = 0.0f32;
-    let gyro_bias_y = 0.0f32;
-    let gyro_bias_z = 0.0f32;
-
     info!("Starting AHRS processing at {} Hz", SAMPLE_RATE_HZ);
 
-    run_imu_command_loop(&mut sensor, &mut madgwick, gyro_bias_x, gyro_bias_y, gyro_bias_z).await;
+    run_imu_command_loop(&mut sensor, &mut madgwick).await;
 }

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -689,7 +689,7 @@ async fn sample_once(
         *last_good_accel_dir = Some(unit);
         unit
     } else if let Some(last) = last_good_accel_dir.as_ref() {
-        last.clone()
+        *last
     } else {
         accel_corrected / accel_norm.max(1e-3)
     };

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -184,6 +184,24 @@ static MAG_AVAILABLE: AtomicBool = AtomicBool::new(false);
 /// Latest IMU orientation snapshot for UI display.
 static LATEST_ORIENTATION: Mutex<CriticalSectionRawMutex, Option<Orientation>> = Mutex::new(None);
 
+/// Latest calibrated accelerometer reading (g).
+static LATEST_CALIBRATED_ACCEL: Mutex<CriticalSectionRawMutex, Option<Vector3<f32>>> = Mutex::new(None);
+
+/// Latest calibrated gyroscope reading (deg/s).
+static LATEST_CALIBRATED_GYRO: Mutex<CriticalSectionRawMutex, Option<Vector3<f32>>> = Mutex::new(None);
+
+/// Latest calibrated magnetometer reading (μT, before normalization).
+static LATEST_CALIBRATED_MAG: Mutex<CriticalSectionRawMutex, Option<Vector3<f32>>> = Mutex::new(None);
+
+/// Latest raw accelerometer reading (g, before bias correction).
+static LATEST_RAW_ACCEL: Mutex<CriticalSectionRawMutex, Option<Vector3<f32>>> = Mutex::new(None);
+
+/// Latest raw gyroscope reading (deg/s, before bias correction).
+static LATEST_RAW_GYRO: Mutex<CriticalSectionRawMutex, Option<Vector3<f32>>> = Mutex::new(None);
+
+/// Latest raw magnetometer reading (μT, before interference correction).
+static LATEST_RAW_MAG: Mutex<CriticalSectionRawMutex, Option<Vector3<f32>>> = Mutex::new(None);
+
 /// Start continuous IMU readings
 pub fn start_imu_readings() {
     IMU_CONTROL.signal(ImuCommand::Start);
@@ -205,6 +223,42 @@ pub fn stop_imu_readings() {
 /// Get the latest IMU orientation for display purposes.
 pub async fn get_latest_orientation() -> Option<Orientation> {
     let latest = LATEST_ORIENTATION.lock().await;
+    *latest
+}
+
+/// Get the latest calibrated accelerometer reading (g).
+pub async fn get_latest_calibrated_accel() -> Option<Vector3<f32>> {
+    let latest = LATEST_CALIBRATED_ACCEL.lock().await;
+    *latest
+}
+
+/// Get the latest calibrated gyroscope reading (deg/s).
+pub async fn get_latest_calibrated_gyro() -> Option<Vector3<f32>> {
+    let latest = LATEST_CALIBRATED_GYRO.lock().await;
+    *latest
+}
+
+/// Get the latest calibrated magnetometer reading (μT, before normalization).
+pub async fn get_latest_calibrated_mag() -> Option<Vector3<f32>> {
+    let latest = LATEST_CALIBRATED_MAG.lock().await;
+    *latest
+}
+
+/// Get the latest raw accelerometer reading (g, before bias correction).
+pub async fn get_latest_raw_accel() -> Option<Vector3<f32>> {
+    let latest = LATEST_RAW_ACCEL.lock().await;
+    *latest
+}
+
+/// Get the latest raw gyroscope reading (deg/s, before bias correction).
+pub async fn get_latest_raw_gyro() -> Option<Vector3<f32>> {
+    let latest = LATEST_RAW_GYRO.lock().await;
+    *latest
+}
+
+/// Get the latest raw magnetometer reading (μT, before interference correction).
+pub async fn get_latest_raw_mag() -> Option<Vector3<f32>> {
+    let latest = LATEST_RAW_MAG.lock().await;
     *latest
 }
 
@@ -429,12 +483,12 @@ async fn configure_imu_sensor(sensor: &mut ImuSensor) -> bool {
     info!("Accelerometer: ±4g, 111Hz DLPF, ~49Hz sample rate");
 
     // Configure gyroscope for tracked robot:
-    // ±500°/s range: Captures fast rotations (tracks can spin quickly)
-    // 51 Hz DLPF: Good vibration filtering for brushed motors
+    // ±1000°/s range: Lower sensitivity, tolerates fast rotations without saturation
+    // 24 Hz DLPF: Stronger filtering for low-noise idle readings
     // ~50 Hz internal sample rate: Matches the 50 Hz readout loop (reduced CPU + I2C load)
     let gyro_config = GyroConfig {
-        full_scale: GyroFullScale::Dps500,
-        dlpf: GyroDlpf::Hz51,
+        full_scale: GyroFullScale::Dps1000,
+        dlpf: GyroDlpf::Hz24,
         dlpf_enable: true,
         sample_rate_div: 22, // (1125 Hz / (1 + 22)) = ~48.9 Hz
     };
@@ -444,7 +498,7 @@ async fn configure_imu_sensor(sensor: &mut ImuSensor) -> bool {
         info!("Sensor configuration failed - IMU task terminating");
         return false;
     }
-    info!("Gyroscope: ±500°/s, 51Hz DLPF, ~49Hz sample rate");
+    info!("Gyroscope: ±1000°/s, 24Hz DLPF, ~49Hz sample rate");
 
     // Configure magnetometer for absolute heading:
     // Continuous 50Hz mode for smooth compass data
@@ -519,6 +573,11 @@ enum SampleOutcome {
     Terminate,
 }
 
+/// Remap IMU axes from sensor frame to robot frame
+fn remap_imu_axes(data: Vector3<f32>) -> Vector3<f32> {
+    Vector3::new(-data.y, data.x, data.z)
+}
+
 /// Read accelerometer data with error handling and failure tracking
 async fn read_accelerometer(
     sensor: &mut ImuSensor,
@@ -527,7 +586,7 @@ async fn read_accelerometer(
     match sensor.read_accelerometer().await {
         Ok(data) => {
             *accel_consecutive_failures = 0;
-            Ok(Vector3::new(data.x, data.y, data.z))
+            Ok(remap_imu_axes(Vector3::new(data.x, data.y, data.z)))
         }
         Err(e) => {
             *accel_consecutive_failures += 1;
@@ -553,7 +612,7 @@ async fn read_gyroscope(
     match sensor.read_gyroscope().await {
         Ok(data) => {
             *gyro_consecutive_failures = 0;
-            Ok(Vector3::new(data.x, data.y, data.z))
+            Ok(remap_imu_axes(Vector3::new(data.x, data.y, data.z)))
         }
         Err(e) => {
             *gyro_consecutive_failures += 1;
@@ -579,7 +638,7 @@ async fn read_magnetometer(
     match sensor.read_magnetometer().await {
         Ok(data) => {
             *mag_consecutive_failures = 0;
-            Ok(Vector3::new(data.x, data.y, data.z))
+            Ok(remap_imu_axes(Vector3::new(data.x, data.y, data.z)))
         }
         Err(e) => {
             *mag_consecutive_failures += 1;
@@ -605,6 +664,11 @@ async fn prepare_magnetometer(
 ) -> Result<(Vector3<f32>, bool), SampleOutcome> {
     let mut mag_data = read_magnetometer(sensor, mag_consecutive_failures).await?;
 
+    {
+        let mut latest = LATEST_RAW_MAG.lock().await;
+        *latest = Some(mag_data);
+    }
+
     // Send raw magnetometer reading to drive task for calibration purposes
     // (before applying interference correction)
     drive::send_mag_measurement(mag_data).await;
@@ -614,6 +678,11 @@ async fn prepare_magnetometer(
         let (left_speed, right_speed) = motion::get_track_speeds_atomic();
         apply_motor_interference_correction(&mut mag_data, cal, left_speed, right_speed);
         apply_mag_calibration(&mut mag_data, cal);
+    }
+
+    {
+        let mut latest = LATEST_CALIBRATED_MAG.lock().await;
+        *latest = Some(mag_data);
     }
 
     // Check if magnetometer reading is reasonable
@@ -641,6 +710,7 @@ async fn sample_once(
     sensor: &mut ImuSensor,
     madgwick: &mut Madgwick<f32>,
     fusion_mode: AhrsFusionMode,
+    dt_seconds: f32,
     current_calibration: Option<&flash_storage::ImuCalibration>,
     last_good_accel_dir: &mut Option<Vector3<f32>>,
     accel_consecutive_failures: &mut u32,
@@ -661,10 +731,21 @@ async fn sample_once(
 
     // Send raw gyroscope reading to drive task for calibration purposes
     // (before bias correction is applied)
-    drive::send_gyro_measurement(Vector3::new(gyro_data.x, gyro_data.y, gyro_data.z)).await;
+    let raw_gyro = Vector3::new(gyro_data.x, gyro_data.y, gyro_data.z);
+    drive::send_gyro_measurement(raw_gyro).await;
+
+    {
+        let mut latest = LATEST_RAW_GYRO.lock().await;
+        *latest = Some(raw_gyro);
+    }
 
     // Send raw accelerometer reading to drive task for calibration purposes
     drive::send_accel_measurement(accel_data).await;
+
+    {
+        let mut latest = LATEST_RAW_ACCEL.lock().await;
+        *latest = Some(accel_data);
+    }
 
     let (gyro_bias_x, gyro_bias_y, gyro_bias_z) = current_calibration.map_or((0.0, 0.0, 0.0), |cal| {
         (cal.gyro_x_bias, cal.gyro_y_bias, cal.gyro_z_bias)
@@ -674,11 +755,21 @@ async fn sample_once(
     let gyro_y = gyro_data.y - gyro_bias_y;
     let gyro_z = gyro_data.z - gyro_bias_z;
 
+    {
+        let mut latest = LATEST_CALIBRATED_GYRO.lock().await;
+        *latest = Some(Vector3::new(gyro_x, gyro_y, gyro_z));
+    }
+
     let mut accel_corrected = accel_data;
     if let Some(cal) = current_calibration {
         accel_corrected.x -= cal.accel_x_bias;
         accel_corrected.y -= cal.accel_y_bias;
         accel_corrected.z -= cal.accel_z_bias;
+    }
+
+    {
+        let mut latest = LATEST_CALIBRATED_ACCEL.lock().await;
+        *latest = Some(accel_corrected);
     }
 
     // Normalize accel and gate it when linear acceleration is likely.
@@ -693,8 +784,10 @@ async fn sample_once(
         accel_corrected / accel_norm.max(1e-3)
     };
 
-    // Convert gyroscope from degrees/s to radians/s for AHRS
-    let gyro_rad = Vector3::new(gyro_x.to_radians(), gyro_y.to_radians(), gyro_z.to_radians());
+    // Convert gyroscope from degrees/s to radians/s for AHRS.
+    // Scale by measured dt to correct for loop timing drift.
+    let dt_ratio = (dt_seconds / (1.0 / SAMPLE_RATE_HZ)).clamp(0.5, 2.0);
+    let gyro_rad = Vector3::new(gyro_x.to_radians(), gyro_y.to_radians(), gyro_z.to_radians()) * dt_ratio;
 
     // NOTE: In 6-axis mode we must NOT read the magnetometer at all.
     // This avoids I2C/mag failures from stalling IMU output during turns.
@@ -742,6 +835,7 @@ async fn sample_once(
 }
 
 /// Main command loop for handling IMU reading state and processing commands
+#[allow(clippy::too_many_lines)]
 async fn run_imu_command_loop(sensor: &mut ImuSensor, madgwick: &mut Madgwick<f32>) {
     // Store current calibration data
     // Calibration will be loaded by orchestrator during initialization
@@ -774,6 +868,7 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor, madgwick: &mut Madgwick<f3
                 let mut last_loop_ts_ms: Option<u32> = None;
                 #[cfg(feature = "telemetry_logs")]
                 let mut last_loop_diag_ts_ms: u32 = 0;
+                let mut last_sample_ms: Option<u64> = None;
 
                 loop {
                     match select(IMU_CONTROL.wait(), Timer::after(SAMPLE_INTERVAL)).await {
@@ -792,10 +887,22 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor, madgwick: &mut Madgwick<f3
                         }
                         Either::First(_) => {}
                         Either::Second(()) => {
+                            let now_ms = Instant::now().as_millis();
+                            let dt_seconds = last_sample_ms.map_or(1.0 / SAMPLE_RATE_HZ, |last| {
+                                let dt_ms = now_ms.saturating_sub(last);
+                                let dt_ms = dt_ms.min(u64::from(u32::MAX));
+                                #[allow(clippy::cast_precision_loss)]
+                                {
+                                    (dt_ms as f32 / 1000.0).clamp(0.005, 0.1)
+                                }
+                            });
+                            last_sample_ms = Some(now_ms);
+
                             match sample_once(
                                 sensor,
                                 madgwick,
                                 fusion_mode,
+                                dt_seconds,
                                 current_calibration.as_ref(),
                                 &mut last_good_accel_dir,
                                 &mut accel_consecutive_failures,
@@ -816,7 +923,14 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor, madgwick: &mut Madgwick<f3
                                             >= IMU_LOOP_DIAG_LOG_INTERVAL_MS
                                         {
                                             let dt_ms = last_loop_ts_ms.map(|last| timestamp_ms.wrapping_sub(last));
-                                            defmt::info!("IMU diag: mode={:?} dt_ms={:?}", fusion_mode, dt_ms);
+                                            let dt_ratio = (dt_seconds / (1.0 / SAMPLE_RATE_HZ)).clamp(0.5, 2.0);
+                                            defmt::info!(
+                                                "IMU diag: mode={:?} dt_ms={:?} dt_s={=f32} dt_ratio={=f32}",
+                                                fusion_mode,
+                                                dt_ms,
+                                                dt_seconds,
+                                                dt_ratio
+                                            );
                                             last_loop_diag_ts_ms = timestamp_ms;
                                         }
                                         last_loop_ts_ms = Some(timestamp_ms);

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -163,6 +163,10 @@ pub enum AhrsFusionMode {
     Axis9,
 }
 
+/// System default for AHRS fusion mode.
+/// Change this to switch the system between 6-axis and 9-axis fusion.
+pub const DEFAULT_FUSION_MODE: AhrsFusionMode = AhrsFusionMode::Axis6;
+
 /// Control commands sent to the IMU task.
 enum ImuCommand {
     /// Start IMU readings
@@ -530,7 +534,7 @@ fn init_madgwick() -> Madgwick<f32> {
     info!("Madgwick AHRS filter initialized:");
     info!("  Sample rate: {} Hz", SAMPLE_RATE_HZ);
     info!("  Beta: {} (balanced for tracked robot)", BETA);
-    info!("  Mode: 9-axis fusion (gyro + accel + mag) when magnetometer is available");
+    info!("  Default fusion mode: {:?}", DEFAULT_FUSION_MODE);
 
     madgwick
 }
@@ -843,12 +847,12 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor, madgwick: &mut Madgwick<f3
     let mut current_calibration: Option<flash_storage::ImuCalibration> = None;
     let mut last_good_accel_dir: Option<Vector3<f32>> = None;
 
-    // Selectable AHRS fusion mode (default to 9-axis for normal operation).
-    // Testing can switch this to Axis6 to avoid magnetometer issues while validating control flow.
-    let mut fusion_mode = if MAG_AVAILABLE.load(Ordering::Relaxed) {
-        AhrsFusionMode::Axis9
-    } else {
+    // Selectable AHRS fusion mode (default to DEFAULT_FUSION_MODE).
+    // Testing can still switch modes explicitly while validating control flow.
+    let mut fusion_mode = if DEFAULT_FUSION_MODE == AhrsFusionMode::Axis9 && !MAG_AVAILABLE.load(Ordering::Relaxed) {
         AhrsFusionMode::Axis6
+    } else {
+        DEFAULT_FUSION_MODE
     };
 
     'command: loop {

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -621,7 +621,13 @@ async fn prepare_magnetometer(
     // Typical Earth's magnetic field: 25-65 μT
     // Lower bound: 20.0 μT rejects clearly invalid readings (below Earth's minimum)
     // Upper bound: 200.0 μT allows for magnetic interference while rejecting sensor errors
+    let mag_norm = mag_data.norm();
     let use_magnetometer = should_use_magnetometer(&mag_data);
+
+    if use_magnetometer {
+        let denom = mag_norm.max(1e-3);
+        mag_data /= denom;
+    }
 
     // Low-rate magnetometer diagnostics to debug yaw "sticking" / magnetic issues.
     // This is especially useful when validating hard/soft-iron calibration and interference correction.
@@ -637,6 +643,7 @@ async fn sample_once(
     madgwick: &mut Madgwick<f32>,
     fusion_mode: AhrsFusionMode,
     current_calibration: Option<&flash_storage::ImuCalibration>,
+    last_good_accel_dir: &mut Option<Vector3<f32>>,
     accel_consecutive_failures: &mut u32,
     gyro_consecutive_failures: &mut u32,
     mag_consecutive_failures: &mut u32,
@@ -675,6 +682,18 @@ async fn sample_once(
         accel_corrected.z -= cal.accel_z_bias;
     }
 
+    // Normalize accel and gate it when linear acceleration is likely.
+    let accel_norm = accel_corrected.norm();
+    let accel_dir = if (0.85..=1.15).contains(&accel_norm) && accel_norm > 0.0 {
+        let unit = accel_corrected / accel_norm;
+        *last_good_accel_dir = Some(unit);
+        unit
+    } else if let Some(last) = last_good_accel_dir.as_ref() {
+        last.clone()
+    } else {
+        accel_corrected / accel_norm.max(1e-3)
+    };
+
     // Convert gyroscope from degrees/s to radians/s for AHRS
     let gyro_rad = Vector3::new(gyro_x.to_radians(), gyro_y.to_radians(), gyro_z.to_radians());
 
@@ -683,7 +702,7 @@ async fn sample_once(
     let result = match fusion_mode {
         AhrsFusionMode::Axis6 => {
             // 6-axis fusion: gyro + accel (yaw will drift over time)
-            madgwick.update_imu(&gyro_rad, &accel_corrected)
+            madgwick.update_imu(&gyro_rad, &accel_dir)
         }
         AhrsFusionMode::Axis9 => {
             let (mag_data, use_magnetometer) =
@@ -694,10 +713,10 @@ async fn sample_once(
 
             if use_magnetometer {
                 // 9-axis fusion: gyro + accel + mag (absolute heading, no yaw drift)
-                madgwick.update(&gyro_rad, &accel_corrected, &mag_data)
+                madgwick.update(&gyro_rad, &accel_dir, &mag_data)
             } else {
                 // 6-axis fallback when mag is not trustworthy
-                madgwick.update_imu(&gyro_rad, &accel_corrected)
+                madgwick.update_imu(&gyro_rad, &accel_dir)
             }
         }
     };
@@ -729,6 +748,7 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor, madgwick: &mut Madgwick<f3
     // Calibration will be loaded by orchestrator during initialization
     // and sent via LoadCalibration command
     let mut current_calibration: Option<flash_storage::ImuCalibration> = None;
+    let mut last_good_accel_dir: Option<Vector3<f32>> = None;
 
     // Selectable AHRS fusion mode (default to 9-axis for normal operation).
     // Testing can switch this to Axis6 to avoid magnetometer issues while validating control flow.
@@ -778,6 +798,7 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor, madgwick: &mut Madgwick<f3
                                 madgwick,
                                 fusion_mode,
                                 current_calibration.as_ref(),
+                                &mut last_good_accel_dir,
                                 &mut accel_consecutive_failures,
                                 &mut gyro_consecutive_failures,
                                 &mut mag_consecutive_failures,

--- a/src/task/testmode/imu_6axis.rs
+++ b/src/task/testmode/imu_6axis.rs
@@ -12,72 +12,73 @@ use heapless::String;
 
 use super::{TestCommand, release_testmode, request_start};
 use crate::task::{
-    drive::{get_latest_accel_measurement, get_latest_gyro_measurement, get_latest_mag_measurement},
     io::display::{DisplayAction, display_update},
     sensors::imu::{
-        AhrsFusionMode, Orientation, get_latest_orientation, set_ahrs_fusion_mode, start_imu_readings,
-        stop_imu_readings,
+        AhrsFusionMode, Orientation, get_latest_calibrated_accel, get_latest_calibrated_gyro, get_latest_orientation,
+        get_latest_raw_accel, get_latest_raw_gyro, set_ahrs_fusion_mode, start_imu_readings, stop_imu_readings,
     },
 };
 
-/// Signal used to stop the IMU test mode.
-static IMU_TEST_STOP_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+/// Signal used to stop the IMU 6-axis test mode.
+static IMU6_TEST_STOP_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
 
-/// Tracks whether the IMU test mode is active.
-static IMU_TEST_ACTIVE: AtomicBool = AtomicBool::new(false);
+/// Tracks whether the IMU 6-axis test mode is active.
+static IMU6_TEST_ACTIVE: AtomicBool = AtomicBool::new(false);
 
-/// Request the IMU test mode to start (spawns the task on demand).
-pub async fn start_imu_test_mode() {
-    if IMU_TEST_ACTIVE.swap(true, Ordering::Relaxed) {
+/// Request the IMU 6-axis test mode to start (spawns the task on demand).
+pub async fn start_imu6_test_mode() {
+    if IMU6_TEST_ACTIVE.swap(true, Ordering::Relaxed) {
         return;
     }
 
-    if !request_start(TestCommand::Imu).await {
-        IMU_TEST_ACTIVE.store(false, Ordering::Relaxed);
+    if !request_start(TestCommand::Imu6).await {
+        IMU6_TEST_ACTIVE.store(false, Ordering::Relaxed);
     }
 }
 
-/// Request the IMU test mode to stop.
-pub fn stop_imu_test_mode() {
-    IMU_TEST_ACTIVE.store(false, Ordering::Relaxed);
-    IMU_TEST_STOP_SIGNAL.signal(());
+/// Request the IMU 6-axis test mode to stop.
+pub fn stop_imu6_test_mode() {
+    IMU6_TEST_ACTIVE.store(false, Ordering::Relaxed);
+    IMU6_TEST_STOP_SIGNAL.signal(());
 }
 
-/// Spawn the IMU test task via the controller.
+/// Spawn the IMU 6-axis test task via the controller.
 pub(super) fn spawn(spawner: Spawner) {
-    spawner.must_spawn(imu_test_task());
+    spawner.must_spawn(imu6_test_task());
 }
 
 /// IMU test mode runner (updates display at 50Hz while active).
 
 #[embassy_executor::task]
-async fn imu_test_task() {
-    set_ahrs_fusion_mode(AhrsFusionMode::Axis9);
+async fn imu6_test_task() {
     start_imu_readings();
+    Timer::after(Duration::from_millis(30)).await;
+    set_ahrs_fusion_mode(AhrsFusionMode::Axis6);
     display_update(DisplayAction::Clear).await;
 
     let mut tick: u32 = 0;
     let mut missing: u32 = 0;
 
     // Clear any pending stop signal so the next test doesn't end immediately.
-    while IMU_TEST_STOP_SIGNAL.signaled() {
-        IMU_TEST_STOP_SIGNAL.wait().await;
+    while IMU6_TEST_STOP_SIGNAL.signaled() {
+        IMU6_TEST_STOP_SIGNAL.wait().await;
     }
 
     loop {
-        match select(IMU_TEST_STOP_SIGNAL.wait(), Timer::after(Duration::from_millis(20))).await {
+        match select(IMU6_TEST_STOP_SIGNAL.wait(), Timer::after(Duration::from_millis(20))).await {
             Either::First(()) => break,
             Either::Second(()) => {
-                if !IMU_TEST_ACTIVE.load(Ordering::Relaxed) {
+                if !IMU6_TEST_ACTIVE.load(Ordering::Relaxed) {
                     break;
                 }
 
                 let orientation = get_latest_orientation().await;
-                let accel = get_latest_accel_measurement().await;
-                let gyro = get_latest_gyro_measurement().await;
-                let mag = get_latest_mag_measurement().await;
+                let accel = get_latest_calibrated_accel().await;
+                let gyro = get_latest_calibrated_gyro().await;
+                let raw_accel = get_latest_raw_accel().await;
+                let raw_gyro = get_latest_raw_gyro().await;
 
-                if orientation.is_none() && accel.is_none() && gyro.is_none() && mag.is_none() {
+                if orientation.is_none() && accel.is_none() && gyro.is_none() {
                     missing = missing.saturating_add(1);
                 } else {
                     missing = 0;
@@ -95,19 +96,33 @@ async fn imu_test_task() {
                     let line2 = format_axis_line("G", gyro);
                     display_update(DisplayAction::ShowText(line2, 2)).await;
 
-                    let line3 = format_axis_line("M", mag);
+                    let mut line3: String<20> = String::new();
+                    let _ = line3.push_str("6-axis");
                     display_update(DisplayAction::ShowText(line3, 3)).await;
                 }
 
                 if tick.is_multiple_of(50) {
                     defmt::debug!(
-                        "IMU test data: ori={} accel={} gyro={} mag={} missing={}",
+                        "IMU6 test data: ori={} accel={} gyro={} missing={}",
                         orientation.is_some(),
                         accel.is_some(),
                         gyro.is_some(),
-                        mag.is_some(),
                         missing
                     );
+
+                    if let (Some(a), Some(g)) = (raw_accel, raw_gyro) {
+                        defmt::debug!(
+                            "IMU6 raw: a=({=f32},{=f32},{=f32}) g=({=f32},{=f32},{=f32})",
+                            a.x,
+                            a.y,
+                            a.z,
+                            g.x,
+                            g.y,
+                            g.z
+                        );
+                    } else {
+                        defmt::debug!("IMU6 raw: accel={} gyro={}", raw_accel.is_some(), raw_gyro.is_some());
+                    }
                 }
             }
         }
@@ -115,7 +130,7 @@ async fn imu_test_task() {
 
     stop_imu_readings();
     release_testmode();
-    IMU_TEST_ACTIVE.store(false, Ordering::Relaxed);
+    IMU6_TEST_ACTIVE.store(false, Ordering::Relaxed);
 }
 
 /// Format an IMU orientation line (Euler angles).
@@ -125,7 +140,7 @@ fn format_orientation_line(orientation: Option<Orientation>) -> String<20> {
         Some(ori) => {
             let _ = core::fmt::write(
                 &mut s,
-                format_args!("E {:.1}/{:.1}/{:.1}", ori.yaw, ori.pitch, ori.roll),
+                format_args!("E y{:.1}/p{:.1}/r{:.1}", ori.yaw, ori.pitch, ori.roll),
             );
         }
         None => {
@@ -140,7 +155,7 @@ fn format_axis_line(prefix: &str, data: Option<nalgebra::Vector3<f32>>) -> Strin
     let mut s: String<20> = String::new();
     match data {
         Some(v) => {
-            let _ = core::fmt::write(&mut s, format_args!("{prefix} {:.1}/{:.1}/{:.1}", v.x, v.y, v.z));
+            let _ = core::fmt::write(&mut s, format_args!("{prefix} x{:.1}/y{:.1}/z{:.1}", v.x, v.y, v.z));
         }
         None => {
             let _ = core::fmt::write(&mut s, format_args!("{prefix} --.-/--.-/--.-"));

--- a/src/task/testmode/imu_9axis.rs
+++ b/src/task/testmode/imu_9axis.rs
@@ -1,0 +1,284 @@
+//! On-demand IMU test mode task.
+//!
+//! Spawns an IMU telemetry task when requested and exits on stop.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use embassy_executor::Spawner;
+use embassy_futures::select::{Either, select};
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use embassy_time::{Duration, Timer};
+use heapless::String;
+use micromath::F32Ext;
+
+use super::{TestCommand, release_testmode, request_start};
+use crate::task::{
+    io::display::{DisplayAction, display_update},
+    sensors::imu::{
+        AhrsFusionMode, Orientation, get_latest_calibrated_accel, get_latest_calibrated_gyro,
+        get_latest_calibrated_mag, get_latest_orientation, get_latest_raw_accel, get_latest_raw_gyro,
+        get_latest_raw_mag, set_ahrs_fusion_mode, start_imu_readings, stop_imu_readings,
+    },
+};
+
+/// Signal used to stop the IMU test mode.
+static IMU_TEST_STOP_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+
+/// Tracks whether the IMU test mode is active.
+static IMU_TEST_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Request the IMU test mode to start (spawns the task on demand).
+pub async fn start_imu_test_mode() {
+    if IMU_TEST_ACTIVE.swap(true, Ordering::Relaxed) {
+        return;
+    }
+
+    if !request_start(TestCommand::Imu).await {
+        IMU_TEST_ACTIVE.store(false, Ordering::Relaxed);
+    }
+}
+
+/// Request the IMU test mode to stop.
+pub fn stop_imu_test_mode() {
+    IMU_TEST_ACTIVE.store(false, Ordering::Relaxed);
+    IMU_TEST_STOP_SIGNAL.signal(());
+}
+
+/// Spawn the IMU test task via the controller.
+pub(super) fn spawn(spawner: Spawner) {
+    spawner.must_spawn(imu_test_task());
+}
+
+/// IMU test mode runner (updates display at 50Hz while active).
+
+#[embassy_executor::task]
+async fn imu_test_task() {
+    start_imu_readings();
+    Timer::after(Duration::from_millis(30)).await;
+    set_ahrs_fusion_mode(AhrsFusionMode::Axis9);
+    display_update(DisplayAction::Clear).await;
+
+    let mut tick: u32 = 0;
+    let mut missing: u32 = 0;
+
+    // Clear any pending stop signal so the next test doesn't end immediately.
+    while IMU_TEST_STOP_SIGNAL.signaled() {
+        IMU_TEST_STOP_SIGNAL.wait().await;
+    }
+
+    loop {
+        match select(IMU_TEST_STOP_SIGNAL.wait(), Timer::after(Duration::from_millis(20))).await {
+            Either::First(()) => break,
+            Either::Second(()) => {
+                if !IMU_TEST_ACTIVE.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                let orientation = get_latest_orientation().await;
+                let accel = get_latest_calibrated_accel().await;
+                let gyro = get_latest_calibrated_gyro().await;
+                let mag = get_latest_calibrated_mag().await;
+                let raw_accel = get_latest_raw_accel().await;
+                let raw_gyro = get_latest_raw_gyro().await;
+                let raw_mag = get_latest_raw_mag().await;
+
+                if orientation.is_none() && accel.is_none() && gyro.is_none() && mag.is_none() {
+                    missing = missing.saturating_add(1);
+                } else {
+                    missing = 0;
+                }
+
+                tick = tick.wrapping_add(1);
+                // Throttle display updates to avoid I2C starvation of the IMU and port expander.
+                if tick.is_multiple_of(5) {
+                    let header = format_orientation_line(orientation);
+                    display_update(DisplayAction::ShowText(header, 0)).await;
+
+                    let line1 = format_axis_line("A", accel);
+                    display_update(DisplayAction::ShowText(line1, 1)).await;
+
+                    let line2 = format_axis_line("G", gyro);
+                    display_update(DisplayAction::ShowText(line2, 2)).await;
+
+                    let line3 = format_axis_line("M9", mag);
+                    display_update(DisplayAction::ShowText(line3, 3)).await;
+                }
+
+                if tick.is_multiple_of(50) {
+                    defmt::debug!(
+                        "IMU test data: ori={} accel={} gyro={} mag={} missing={}",
+                        orientation.is_some(),
+                        accel.is_some(),
+                        gyro.is_some(),
+                        mag.is_some(),
+                        missing
+                    );
+
+                    if let (Some(a), Some(g), Some(m)) = (raw_accel, raw_gyro, raw_mag) {
+                        log_mag_diagnostics(a, g, m, orientation);
+                    } else {
+                        defmt::debug!(
+                            "IMU raw: accel={} gyro={} mag={}",
+                            raw_accel.is_some(),
+                            raw_gyro.is_some(),
+                            raw_mag.is_some()
+                        );
+                        defmt::debug!("IMU mag gate: |m|=n/a use_mag=false");
+                    }
+                }
+            }
+        }
+    }
+
+    stop_imu_readings();
+    release_testmode();
+    IMU_TEST_ACTIVE.store(false, Ordering::Relaxed);
+}
+
+/// Log raw IMU vectors and heading remap diagnostics.
+#[allow(clippy::similar_names)]
+fn log_mag_diagnostics(
+    accel: nalgebra::Vector3<f32>,
+    gyro: nalgebra::Vector3<f32>,
+    mag: nalgebra::Vector3<f32>,
+    orientation: Option<Orientation>,
+) {
+    defmt::debug!(
+        "IMU raw: a=({=f32},{=f32},{=f32}) g=({=f32},{=f32},{=f32}) m=({=f32},{=f32},{=f32})",
+        accel.x,
+        accel.y,
+        accel.z,
+        gyro.x,
+        gyro.y,
+        gyro.z,
+        mag.x,
+        mag.y,
+        mag.z
+    );
+    let mag_norm = mag.norm();
+    let use_mag = mag_norm > 20.0 && mag_norm < 200.0;
+    defmt::debug!("IMU mag gate: |m|={=f32} use_mag={}", mag_norm, use_mag);
+
+    let headings_xy = [
+        mag.y.atan2(mag.x).to_degrees(),
+        mag.x.atan2(mag.y).to_degrees(),
+        mag.y.atan2(-mag.x).to_degrees(),
+        (-mag.y).atan2(mag.x).to_degrees(),
+        (-mag.y).atan2(-mag.x).to_degrees(),
+        mag.x.atan2(-mag.y).to_degrees(),
+        (-mag.x).atan2(mag.y).to_degrees(),
+        (-mag.x).atan2(-mag.y).to_degrees(),
+    ];
+
+    defmt::debug!(
+        "IMU mag remap headings: xy={=f32} yx={=f32} -x,y={=f32} x,-y={=f32} -x,-y={=f32} -y,x={=f32} y,-x={=f32} -y,-x={=f32}",
+        headings_xy[0],
+        headings_xy[1],
+        headings_xy[2],
+        headings_xy[3],
+        headings_xy[4],
+        headings_xy[5],
+        headings_xy[6],
+        headings_xy[7]
+    );
+
+    let headings_xz = [
+        mag.z.atan2(mag.x).to_degrees(),
+        mag.x.atan2(mag.z).to_degrees(),
+        mag.z.atan2(-mag.x).to_degrees(),
+        (-mag.z).atan2(mag.x).to_degrees(),
+        (-mag.z).atan2(-mag.x).to_degrees(),
+        mag.x.atan2(-mag.z).to_degrees(),
+        (-mag.x).atan2(mag.z).to_degrees(),
+        (-mag.x).atan2(-mag.z).to_degrees(),
+    ];
+
+    defmt::debug!(
+        "IMU mag remap headings xz-plane: xz={=f32} zx={=f32} -x,z={=f32} x,-z={=f32} -x,-z={=f32} -z,x={=f32} z,-x={=f32} -z,-x={=f32}",
+        headings_xz[0],
+        headings_xz[1],
+        headings_xz[2],
+        headings_xz[3],
+        headings_xz[4],
+        headings_xz[5],
+        headings_xz[6],
+        headings_xz[7]
+    );
+
+    let headings_yz = [
+        mag.z.atan2(mag.y).to_degrees(),
+        mag.y.atan2(mag.z).to_degrees(),
+        mag.z.atan2(-mag.y).to_degrees(),
+        (-mag.z).atan2(mag.y).to_degrees(),
+        (-mag.z).atan2(-mag.y).to_degrees(),
+        mag.y.atan2(-mag.z).to_degrees(),
+        (-mag.y).atan2(mag.z).to_degrees(),
+        (-mag.y).atan2(-mag.z).to_degrees(),
+    ];
+
+    defmt::debug!(
+        "IMU mag remap headings yz-plane: yz={=f32} zy={=f32} -y,z={=f32} y,-z={=f32} -y,-z={=f32} -z,y={=f32} z,-y={=f32} -z,-y={=f32}",
+        headings_yz[0],
+        headings_yz[1],
+        headings_yz[2],
+        headings_yz[3],
+        headings_yz[4],
+        headings_yz[5],
+        headings_yz[6],
+        headings_yz[7]
+    );
+
+    let raw_heading = headings_xy[0];
+
+    let roll = accel.y.atan2(accel.z);
+    let pitch = (-accel.x).atan2((accel.y * accel.y + accel.z * accel.z).sqrt());
+    let mx2 = mag.x * pitch.cos() + mag.z * pitch.sin();
+    let my2 = mag.x * roll.sin() * pitch.sin() + mag.y * roll.cos() - mag.z * roll.sin() * pitch.cos();
+    let tilt_heading = my2.atan2(mx2).to_degrees();
+
+    if let Some(ori) = orientation {
+        defmt::debug!(
+            "IMU heading: raw={=f32} tilt={=f32} ahrs_yaw={=f32}",
+            raw_heading,
+            tilt_heading,
+            ori.yaw
+        );
+    } else {
+        defmt::debug!(
+            "IMU heading: raw={=f32} tilt={=f32} ahrs_yaw=n/a",
+            raw_heading,
+            tilt_heading
+        );
+    }
+}
+
+/// Format an IMU orientation line (Euler angles).
+fn format_orientation_line(orientation: Option<Orientation>) -> String<20> {
+    let mut s: String<20> = String::new();
+    match orientation {
+        Some(ori) => {
+            let _ = core::fmt::write(
+                &mut s,
+                format_args!("E y{:.1}/p{:.1}/r{:.1}", ori.yaw, ori.pitch, ori.roll),
+            );
+        }
+        None => {
+            let _ = core::fmt::write(&mut s, format_args!("E --.-/--.-/--.-"));
+        }
+    }
+    s
+}
+
+/// Format a 3-axis sensor line (accel/gyro/mag).
+fn format_axis_line(prefix: &str, data: Option<nalgebra::Vector3<f32>>) -> String<20> {
+    let mut s: String<20> = String::new();
+    match data {
+        Some(v) => {
+            let _ = core::fmt::write(&mut s, format_args!("{prefix} x{:.1}/y{:.1}/z{:.1}", v.x, v.y, v.z));
+        }
+        None => {
+            let _ = core::fmt::write(&mut s, format_args!("{prefix} --.-/--.-/--.-"));
+        }
+    }
+    s
+}

--- a/src/task/testmode/mod.rs
+++ b/src/task/testmode/mod.rs
@@ -8,13 +8,15 @@ use embassy_executor::Spawner;
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Channel};
 
 pub mod basic_motor;
-pub mod imu;
+pub mod imu_6axis;
+pub mod imu_9axis;
 pub mod ir_ultrasonic;
 pub mod sequence;
 pub mod ultrasonic_sweep;
 
 pub use basic_motor::{start_basic_motor_test_mode, stop_basic_motor_test_mode};
-pub use imu::{start_imu_test_mode, stop_imu_test_mode};
+pub use imu_6axis::{start_imu6_test_mode, stop_imu6_test_mode};
+pub use imu_9axis::{start_imu_test_mode, stop_imu_test_mode};
 pub use ir_ultrasonic::{start_ir_ultrasonic_test_mode, stop_ir_ultrasonic_test_mode};
 pub use sequence::start_testing_sequence;
 pub use ultrasonic_sweep::{start_ultrasonic_sweep_test_mode, stop_ultrasonic_sweep_test_mode};
@@ -26,6 +28,8 @@ pub(super) enum TestCommand {
     Sequence,
     /// Spawn the IMU telemetry test.
     Imu,
+    /// Spawn the IMU 6-axis telemetry test.
+    Imu6,
     /// Spawn the IR + ultrasonic test.
     IrUltrasonic,
     /// Spawn the ultrasonic sweep test.
@@ -70,7 +74,8 @@ async fn testmode_controller(spawner: Spawner) {
     loop {
         match TESTMODE_COMMAND.receive().await {
             TestCommand::Sequence => sequence::spawn(spawner),
-            TestCommand::Imu => imu::spawn(spawner),
+            TestCommand::Imu => imu_9axis::spawn(spawner),
+            TestCommand::Imu6 => imu_6axis::spawn(spawner),
             TestCommand::IrUltrasonic => ir_ultrasonic::spawn(spawner),
             TestCommand::UltrasonicSweep => ultrasonic_sweep::spawn(spawner),
             TestCommand::BasicMotor => basic_motor::spawn(spawner),

--- a/src/task/ui/menu.rs
+++ b/src/task/ui/menu.rs
@@ -42,9 +42,10 @@ pub const fn test_selection_from_index(index: usize) -> Option<TestSelection> {
     match index {
         0 => Some(TestSelection::Combined),
         1 => Some(TestSelection::Imu),
-        2 => Some(TestSelection::BasicMotor),
-        3 => Some(TestSelection::IrUltrasonic),
-        4 => Some(TestSelection::UltrasonicSweep),
+        2 => Some(TestSelection::Imu6),
+        3 => Some(TestSelection::BasicMotor),
+        4 => Some(TestSelection::IrUltrasonic),
+        5 => Some(TestSelection::UltrasonicSweep),
         _ => None,
     }
 }

--- a/src/task/ui/mod.rs
+++ b/src/task/ui/mod.rs
@@ -89,6 +89,7 @@ pub async fn handle_rotary_turned(direction: RotaryDirection) {
         }
         UiMode::RunningTest
         | UiMode::RunningImuTest
+        | UiMode::RunningImu6Test
         | UiMode::RunningBasicMotorTest
         | UiMode::RunningIrUltrasonicTest
         | UiMode::RunningUltrasonicSweepTest
@@ -120,6 +121,7 @@ pub async fn handle_rotary_button_pressed() {
             }
         }
         UiMode::RunningImuTest => handle_running_imu_test_press().await,
+        UiMode::RunningImu6Test => handle_running_imu6_test_press().await,
         UiMode::RunningBasicMotorTest => handle_running_basic_motor_test_press().await,
         UiMode::RunningIrUltrasonicTest => handle_running_ir_ultrasonic_test_press().await,
         UiMode::RunningUltrasonicSweepTest => handle_running_ultrasonic_sweep_test_press().await,
@@ -175,6 +177,10 @@ pub async fn handle_ui_back() {
         }
         UiMode::RunningImuTest => {
             testmode::stop_imu_test_mode();
+            show_test_menu().await;
+        }
+        UiMode::RunningImu6Test => {
+            testmode::stop_imu6_test_mode();
             show_test_menu().await;
         }
         UiMode::RunningBasicMotorTest => {
@@ -313,6 +319,14 @@ async fn handle_test_menu_press(index: usize) {
             render_current_ui(&snapshot).await;
             testmode::start_imu_test_mode().await;
         }
+        Some(TestSelection::Imu6) => {
+            let mut ui = UI_STATE.lock().await;
+            ui.mode = UiMode::RunningImu6Test;
+            let snapshot = *ui;
+            drop(ui);
+            render_current_ui(&snapshot).await;
+            testmode::start_imu6_test_mode().await;
+        }
         Some(TestSelection::BasicMotor) => {
             let mut ui = UI_STATE.lock().await;
             ui.mode = UiMode::RunningBasicMotorTest;
@@ -352,6 +366,12 @@ async fn handle_test_menu_press(index: usize) {
 /// Handle a button press while the IMU test mode is active.
 async fn handle_running_imu_test_press() {
     testmode::stop_imu_test_mode();
+    show_test_menu().await;
+}
+
+/// Handle a button press while the IMU 6-axis test mode is active.
+async fn handle_running_imu6_test_press() {
+    testmode::stop_imu6_test_mode();
     show_test_menu().await;
 }
 

--- a/src/task/ui/render.rs
+++ b/src/task/ui/render.rs
@@ -33,6 +33,9 @@ pub async fn render_current_ui(state: &UiState) {
         UiMode::RunningImuTest => {
             render_imu_test_running().await;
         }
+        UiMode::RunningImu6Test => {
+            render_imu6_test_running().await;
+        }
         UiMode::RunningBasicMotorTest => {
             render_basic_motor_test_running().await;
         }
@@ -63,7 +66,16 @@ pub async fn render_test_running() {
 /// Render the IMU test placeholder screen.
 pub async fn render_imu_test_running() {
     display::display_update(DisplayAction::Clear).await;
-    show_line(0, "IMU Test").await;
+    show_line(0, "IMU Test 9-axis").await;
+    show_line(1, "Euler angles").await;
+    show_line(2, "Streaming...").await;
+    show_line(3, "Press to exit").await;
+}
+
+/// Render the IMU 6-axis test placeholder screen.
+pub async fn render_imu6_test_running() {
+    display::display_update(DisplayAction::Clear).await;
+    show_line(0, "IMU Test 6-axis").await;
     show_line(1, "Euler angles").await;
     show_line(2, "Streaming...").await;
     show_line(3, "Press to exit").await;

--- a/src/task/ui/screens.rs
+++ b/src/task/ui/screens.rs
@@ -25,9 +25,10 @@ pub const MAIN_MENU_ITEMS: [&str; 4] = ["System Info", "Calibrate", "Drive Mode"
 pub const DRIVE_MODE_MENU_ITEMS: [&str; 2] = ["Coast & Avoid", "Back"];
 
 /// Test mode submenu entries.
-pub const TEST_MENU_ITEMS: [&str; 6] = [
+pub const TEST_MENU_ITEMS: [&str; 7] = [
     "Combined Test",
-    "IMU Test",
+    "IMU Test (9-axis)",
+    "IMU Test (6-axis)",
     "Basic Motor Test",
     "IR+US Test",
     "US Sweep",

--- a/src/task/ui/state.rs
+++ b/src/task/ui/state.rs
@@ -30,6 +30,8 @@ pub enum UiMode {
     RunningTest,
     /// IMU test mode (live display)
     RunningImuTest,
+    /// IMU test mode (6-axis live display)
+    RunningImu6Test,
     /// Basic motor test mode
     RunningBasicMotorTest,
     /// IR + ultrasonic live test mode


### PR DESCRIPTION
calibration is unusable and needed rework, this is the first stab at making the imu calibration workable.
Splits up into three distinct actions, backed by menu.
Adds normalization to mag and accel, because we expect issues at least with the mag when motors are running and the accel when accelerating too hard, wat ever that may mean in practice.