### PR TITLE
Bump deps, lower log level, handle ultrasonic NaN

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,4 +5,4 @@ runner = "probe-rs run --chip RP235x --protocol swd --speed 16000"
 target = "thumbv8m.main-none-eabihf"
 
 [env]
-DEFMT_LOG = "debug"
+DEFMT_LOG = "info"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ nanorand = { version = "0.8.0", features = [
     "wyrand",
 ], default-features = false }
 hcsr04_async = { version = "0.5.0", features = ["blocking_trigger"] }
-moving_median = "0.3.0"
+moving_median = "0.4.0"
 ssd1306-async = { git = "https://github.com/kalkyl/ssd1306-async" }
 embedded-graphics = "0.8.1"
 static_cell = { version = "2.1.1", features = [] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]
 targets = ["thumbv8m.main-none-eabihf"]

--- a/src/task/behavior/battery.rs
+++ b/src/task/behavior/battery.rs
@@ -1,12 +1,12 @@
 //! Battery-related behavior handlers.
 
-use defmt::info;
+use defmt::debug;
 
 use crate::{system::state::power, task::indicators::rgb_led_indicate};
 
 /// Handle battery measurement (level and voltage).
 pub async fn handle_battery_measured(level: u8, voltage: f32) {
-    info!("Battery level measured");
+    debug!("Battery level measured");
 
     {
         let mut state = power::POWER_STATE.lock().await;

--- a/src/task/sensors/ultrasonic.rs
+++ b/src/task/sensors/ultrasonic.rs
@@ -410,8 +410,11 @@ pub async fn ultrasonic_sweep(
                 match with_timeout(embassy_time::Duration::from_millis(20), sensor_fut).await {
                     Ok(Ok(distance_cm)) => {
                         if distance_cm <= ULTRASONIC_MAX_DISTANCE_CM {
-                            median_filter.add_value(distance_cm);
-                            had_success = true;
+                            if median_filter.add_value(distance_cm).is_err() {
+                                saw_error = true; // at this point can only happen if adding NaN, which shouldn't happen
+                            } else {
+                                had_success = true;
+                            }
                         }
                     }
                     Ok(Err(e)) => {
@@ -425,7 +428,9 @@ pub async fn ultrasonic_sweep(
             }
 
             reading = if had_success {
-                UltrasonicReading::Distance(median_filter.median())
+                median_filter
+                    .median()
+                    .map_or(UltrasonicReading::Error, UltrasonicReading::Distance)
             } else if saw_error {
                 UltrasonicReading::Error
             } else {


### PR DESCRIPTION
Update rust toolchain to 1.96.0 and bump moving_median to 0.4.0. Set DEFMT_LOG to info and change battery log to use debug. Make ultrasonic median filter propagate add_value errors and map None median to UltrasonicReading::Error.