### PR TITLE
Consolidate IMU sensor state into a single struct

### DIFF
--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -202,7 +202,8 @@ pub struct ImuReadings {
     pub orientation: Option<Orientation>,
     /// DMP-calibrated gyroscope (deg/s, internal bias subtracted).
     pub calibrated_gyro: Option<Vector3<f32>>,
-    /// Host-corrected magnetometer (µT, hard/soft-iron + motor-interference).
+    /// Magnetometer reading (µT). Host-corrected when calibration is loaded;
+    /// otherwise the raw value.
     pub calibrated_mag: Option<Vector3<f32>>,
     /// Raw accelerometer (g, before DMP correction).
     pub raw_accel: Option<Vector3<f32>>,

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -193,7 +193,8 @@ static LATEST_READINGS: Mutex<CriticalSectionRawMutex, ImuReadings> = Mutex::new
 /// Snapshot of all IMU sensor data updated on every valid DMP packet.
 ///
 /// Fields are `None` before the first packet arrives. Magnetometer fields
-/// (`calibrated_mag`, `raw_mag`) remain `None` in `Axis6` fusion mode.
+/// (`calibrated_mag`, `raw_mag`) are `None` before the first `Axis9` packet
+/// arrives and are cleared when switching to `Axis6` fusion mode.
 pub struct ImuReadings {
     /// DMP-derived orientation.
     pub orientation: Option<Orientation>,
@@ -380,13 +381,9 @@ async fn update_statics_from_dmp(packet: &icm20948::dmp::DmpData, calibration: O
             f32::from(my) * MAG_SCALE_UT,
             f32::from(mz) * MAG_SCALE_UT,
         );
-        readings.raw_mag = Some(v);
-        drop(readings);
 
-        // Forward raw mag to the drive task for the magnetometer calibration procedure.
-        drive::send_mag_measurement(v).await;
-
-        // Apply host-side hard/soft-iron + motor-interference correction if calibrated.
+        // Compute host-side correction before releasing the lock so callers
+        // of get_latest_readings() see both magnetometer fields updated together.
         let mut mag_cal = v;
         if let Some(cal) = calibration {
             let (left_speed, right_speed) = motion::get_track_speeds_atomic();
@@ -395,7 +392,13 @@ async fn update_statics_from_dmp(packet: &icm20948::dmp::DmpData, calibration: O
             mag_cal.y = (v.y - iy - cal.mag_y_bias) * cal.mag_y_scale;
             mag_cal.z = (v.z - iz - cal.mag_z_bias) * cal.mag_z_scale;
         }
-        LATEST_READINGS.lock().await.calibrated_mag = Some(mag_cal);
+
+        readings.raw_mag = Some(v);
+        readings.calibrated_mag = Some(mag_cal);
+        drop(readings);
+
+        // Forward raw mag to the drive task for the magnetometer calibration procedure.
+        drive::send_mag_measurement(v).await;
     }
 }
 
@@ -558,6 +561,13 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor) {
                                 let new_config = build_dmp_config(fusion_mode);
                                 if !apply_dmp_config(sensor, &new_config).await {
                                     warn!("DMP mode switch failed — continuing on previous config");
+                                }
+                                // Axis6 never produces magnetometer data — clear
+                                // any stale values left from a previous Axis9 session.
+                                if fusion_mode == DmpFusionMode::Axis6 {
+                                    let mut readings = LATEST_READINGS.lock().await;
+                                    readings.raw_mag = None;
+                                    readings.calibrated_mag = None;
                                 }
                                 fifo_failures = 0;
                             }

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -344,50 +344,38 @@ async fn update_statics_from_dmp(
     orientation: Option<Orientation>,
     calibration: Option<&flash_storage::ImuCalibration>,
 ) {
-    let mut readings = LATEST_READINGS.lock().await;
-
-    // DMP-derived orientation (none during warm-up) -------------------------
-    if let Some(o) = orientation {
-        readings.orientation = Some(o);
-    }
-
-    // Raw accelerometer -------------------------------------------------------
-    if let Some((ax, ay, az)) = packet.raw_accel {
-        readings.raw_accel = Some(Vector3::new(
+    // ── Precompute all scaled vectors outside the critical section ──────────
+    let raw_accel_opt: Option<Vector3<f32>> = packet.raw_accel.map(|(ax, ay, az)| {
+        Vector3::new(
             f32::from(ax) * ACCEL_SCALE_G,
             f32::from(ay) * ACCEL_SCALE_G,
             f32::from(az) * ACCEL_SCALE_G,
-        ));
-    }
+        )
+    });
 
-    // Raw gyroscope -----------------------------------------------------------
-    if let Some((gx, gy, gz)) = packet.raw_gyro {
-        readings.raw_gyro = Some(Vector3::new(
+    let raw_gyro_opt: Option<Vector3<f32>> = packet.raw_gyro.map(|(gx, gy, gz)| {
+        Vector3::new(
             f32::from(gx) * GYRO_SCALE_DPS,
             f32::from(gy) * GYRO_SCALE_DPS,
             f32::from(gz) * GYRO_SCALE_DPS,
-        ));
-    }
+        )
+    });
 
-    // DMP-calibrated gyroscope (bias subtracted by DMP calibration engine) ----
-    if let Some((gx, gy, gz)) = packet.calibrated_gyro {
-        readings.calibrated_gyro = Some(Vector3::new(
+    let calibrated_gyro_opt: Option<Vector3<f32>> = packet.calibrated_gyro.map(|(gx, gy, gz)| {
+        Vector3::new(
             f32::from(gx) * GYRO_SCALE_DPS,
             f32::from(gy) * GYRO_SCALE_DPS,
             f32::from(gz) * GYRO_SCALE_DPS,
-        ));
-    }
+        )
+    });
 
-    // Raw magnetometer (Axis9 mode only) --------------------------------------
-    if let Some((mx, my, mz)) = packet.raw_mag {
+    // Raw magnetometer with optional host-side calibration ------------------
+    let mag_data: Option<(Vector3<f32>, Vector3<f32>)> = packet.raw_mag.map(|(mx, my, mz)| {
         let v = Vector3::new(
             f32::from(mx) * MAG_SCALE_UT,
             f32::from(my) * MAG_SCALE_UT,
             f32::from(mz) * MAG_SCALE_UT,
         );
-
-        // Compute host-side correction before releasing the lock so callers
-        // of get_latest_readings() see both magnetometer fields updated together.
         let mut mag_cal = v;
         if let Some(cal) = calibration {
             let (left_speed, right_speed) = motion::get_track_speeds_atomic();
@@ -396,13 +384,33 @@ async fn update_statics_from_dmp(
             mag_cal.y = (v.y - iy - cal.mag_y_bias) * cal.mag_y_scale;
             mag_cal.z = (v.z - iz - cal.mag_z_bias) * cal.mag_z_scale;
         }
+        (v, mag_cal)
+    });
 
-        readings.raw_mag = Some(v);
-        readings.calibrated_mag = Some(mag_cal);
-        drop(readings);
+    // ── Commit snapshot under one lock, then release for the async send ────
+    let mut readings = LATEST_READINGS.lock().await;
 
-        // Forward raw mag to the drive task for the magnetometer calibration procedure.
-        drive::send_mag_measurement(v).await;
+    if let Some(o) = orientation {
+        readings.orientation = Some(o);
+    }
+    if let Some(v) = raw_accel_opt {
+        readings.raw_accel = Some(v);
+    }
+    if let Some(v) = raw_gyro_opt {
+        readings.raw_gyro = Some(v);
+    }
+    if let Some(v) = calibrated_gyro_opt {
+        readings.calibrated_gyro = Some(v);
+    }
+    if let Some((raw, cal)) = mag_data {
+        readings.raw_mag = Some(raw);
+        readings.calibrated_mag = Some(cal);
+    }
+    drop(readings);
+
+    // Forward raw mag to the drive task for the magnetometer calibration procedure.
+    if let Some((raw, _cal)) = mag_data {
+        drive::send_mag_measurement(raw).await;
     }
 }
 

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -195,6 +195,7 @@ static LATEST_READINGS: Mutex<CriticalSectionRawMutex, ImuReadings> = Mutex::new
 /// Fields are `None` before the first packet arrives. Magnetometer fields
 /// (`calibrated_mag`, `raw_mag`) are `None` before the first `Axis9` packet
 /// arrives and are cleared when switching to `Axis6` fusion mode.
+#[derive(Debug, Clone, Copy, Default)]
 pub struct ImuReadings {
     /// DMP-derived orientation.
     pub orientation: Option<Orientation>,
@@ -240,15 +241,7 @@ pub fn load_imu_calibration(calibration: flash_storage::ImuCalibration) {
 
 /// Return a snapshot of all latest IMU readings from a single lock.
 pub async fn get_latest_readings() -> ImuReadings {
-    let r = LATEST_READINGS.lock().await;
-    ImuReadings {
-        orientation: r.orientation,
-        calibrated_gyro: r.calibrated_gyro,
-        calibrated_mag: r.calibrated_mag,
-        raw_accel: r.raw_accel,
-        raw_gyro: r.raw_gyro,
-        raw_mag: r.raw_mag,
-    }
+    *LATEST_READINGS.lock().await
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
@@ -344,8 +337,17 @@ fn interpolate_interference(
 }
 
 /// Update the shared `LATEST_READINGS` and drive-task sensor channels from a DMP packet.
-async fn update_statics_from_dmp(packet: &icm20948::dmp::DmpData, calibration: Option<&flash_storage::ImuCalibration>) {
+async fn update_statics_from_dmp(
+    packet: &icm20948::dmp::DmpData,
+    orientation: Option<Orientation>,
+    calibration: Option<&flash_storage::ImuCalibration>,
+) {
     let mut readings = LATEST_READINGS.lock().await;
+
+    // DMP-derived orientation (none during warm-up) -------------------------
+    if let Some(o) = orientation {
+        readings.orientation = Some(o);
+    }
 
     // Raw accelerometer -------------------------------------------------------
     if let Some((ax, ay, az)) = packet.raw_accel {
@@ -555,19 +557,20 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor) {
                             if new_mode == fusion_mode {
                                 info!("IMU fusion mode already {:?} — no change", fusion_mode);
                             } else {
-                                fusion_mode = new_mode;
-                                info!("Switching DMP fusion mode to {:?}", fusion_mode);
                                 let _ = sensor.dmp_enable(false).await;
-                                let new_config = build_dmp_config(fusion_mode);
-                                if !apply_dmp_config(sensor, &new_config).await {
-                                    warn!("DMP mode switch failed — continuing on previous config");
-                                }
-                                // Axis6 never produces magnetometer data — clear
-                                // any stale values left from a previous Axis9 session.
-                                if fusion_mode == DmpFusionMode::Axis6 {
-                                    let mut readings = LATEST_READINGS.lock().await;
-                                    readings.raw_mag = None;
-                                    readings.calibrated_mag = None;
+                                let new_config = build_dmp_config(new_mode);
+                                if apply_dmp_config(sensor, &new_config).await {
+                                    fusion_mode = new_mode;
+                                    info!("Switched DMP fusion mode to {:?}", fusion_mode);
+                                    // Axis6 never produces magnetometer data — clear
+                                    // any stale values left from a previous Axis9 session.
+                                    if fusion_mode == DmpFusionMode::Axis6 {
+                                        let mut readings = LATEST_READINGS.lock().await;
+                                        readings.raw_mag = None;
+                                        readings.calibrated_mag = None;
+                                    }
+                                } else {
+                                    warn!("DMP mode switch failed — continuing with {:?}", fusion_mode);
                                 }
                                 fifo_failures = 0;
                             }
@@ -596,9 +599,12 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor) {
                                         let orientation = dmp_quat_to_orientation(quat);
                                         let timestamp_ms = Instant::now().as_millis();
 
-                                        LATEST_READINGS.lock().await.orientation = Some(orientation);
-
-                                        update_statics_from_dmp(&packet, current_calibration.as_ref()).await;
+                                        update_statics_from_dmp(
+                                            &packet,
+                                            Some(orientation),
+                                            current_calibration.as_ref(),
+                                        )
+                                        .await;
 
                                         let measurement = ImuMeasurement {
                                             orientation,
@@ -625,7 +631,7 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor) {
                                         raise_event(Events::ImuMeasurementTaken(measurement)).await;
                                     } else {
                                         // Packet present but no quaternion yet (DMP warming up).
-                                        update_statics_from_dmp(&packet, current_calibration.as_ref()).await;
+                                        update_statics_from_dmp(&packet, None, current_calibration.as_ref()).await;
                                     }
                                 }
 

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -574,7 +574,10 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor) {
                                 } else {
                                     warn!("DMP mode switch failed — restoring previous {:?}", fusion_mode);
                                     let old_config = build_dmp_config(fusion_mode);
-                                    let _ = apply_dmp_config(sensor, &old_config).await;
+                                    if !apply_dmp_config(sensor, &old_config).await {
+                                        warn!("DMP restore failed — returning to standby");
+                                        continue 'command;
+                                    }
                                 }
                                 fifo_failures = 0;
                             }

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -29,7 +29,7 @@
 //! # Calibration
 //!
 //! Magnetometer hard/soft-iron and motor-interference correction are applied in
-//! software to the raw mag readings exposed via `LATEST_CALIBRATED_MAG`. The DMP's
+//! software to the raw mag readings exposed via `ImuReadings::calibrated_mag`. The DMP's
 //! own internal calibration engines handle gyroscope and accelerometer bias correction
 //! automatically — no host-injected bias values are needed for those axes.
 //!
@@ -180,23 +180,34 @@ static IMU_CONTROL: Signal<CriticalSectionRawMutex, ImuCommand> = Signal::new();
 /// `true` when `dmp_init_magnetometer` succeeded at start-up; gates `Axis9` usage.
 static MAG_AVAILABLE: AtomicBool = AtomicBool::new(false);
 
-/// Latest DMP-derived orientation snapshot (updated on every valid packet).
-static LATEST_ORIENTATION: Mutex<CriticalSectionRawMutex, Option<Orientation>> = Mutex::new(None);
+/// Latest IMU readings snapshot — one mutex, one accessor.
+static LATEST_READINGS: Mutex<CriticalSectionRawMutex, ImuReadings> = Mutex::new(ImuReadings {
+    orientation: None,
+    calibrated_gyro: None,
+    calibrated_mag: None,
+    raw_accel: None,
+    raw_gyro: None,
+    raw_mag: None,
+});
 
-/// Latest DMP-calibrated gyroscope reading (deg/s, DMP internal bias subtracted).
-static LATEST_CALIBRATED_GYRO: Mutex<CriticalSectionRawMutex, Option<Vector3<f32>>> = Mutex::new(None);
-
-/// Latest magnetometer reading with hard/soft-iron + motor-interference correction (µT).
-static LATEST_CALIBRATED_MAG: Mutex<CriticalSectionRawMutex, Option<Vector3<f32>>> = Mutex::new(None);
-
-/// Latest raw accelerometer reading before DMP correction (g).
-static LATEST_RAW_ACCEL: Mutex<CriticalSectionRawMutex, Option<Vector3<f32>>> = Mutex::new(None);
-
-/// Latest raw gyroscope reading before DMP correction (deg/s).
-static LATEST_RAW_GYRO: Mutex<CriticalSectionRawMutex, Option<Vector3<f32>>> = Mutex::new(None);
-
-/// Latest raw magnetometer reading before any host correction (µT).
-static LATEST_RAW_MAG: Mutex<CriticalSectionRawMutex, Option<Vector3<f32>>> = Mutex::new(None);
+/// Snapshot of all IMU sensor data updated on every valid DMP packet.
+///
+/// Fields are `None` before the first packet arrives. Magnetometer fields
+/// (`calibrated_mag`, `raw_mag`) remain `None` in `Axis6` fusion mode.
+pub struct ImuReadings {
+    /// DMP-derived orientation.
+    pub orientation: Option<Orientation>,
+    /// DMP-calibrated gyroscope (deg/s, internal bias subtracted).
+    pub calibrated_gyro: Option<Vector3<f32>>,
+    /// Host-corrected magnetometer (µT, hard/soft-iron + motor-interference).
+    pub calibrated_mag: Option<Vector3<f32>>,
+    /// Raw accelerometer (g, before DMP correction).
+    pub raw_accel: Option<Vector3<f32>>,
+    /// Raw gyroscope (deg/s, before DMP correction).
+    pub raw_gyro: Option<Vector3<f32>>,
+    /// Raw magnetometer (µT, before any host correction).
+    pub raw_mag: Option<Vector3<f32>>,
+}
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
@@ -221,39 +232,22 @@ pub fn set_dmp_fusion_mode(mode: DmpFusionMode) {
 
 /// Load magnetometer calibration data (hard/soft-iron + motor-interference).
 ///
-/// Applied to `LATEST_CALIBRATED_MAG` on every subsequent DMP packet.
+/// Applied to `ImuReadings::calibrated_mag` on every subsequent DMP packet.
 pub fn load_imu_calibration(calibration: flash_storage::ImuCalibration) {
     IMU_CONTROL.signal(ImuCommand::LoadCalibration(calibration));
 }
 
-/// Return the latest DMP-derived orientation.
-pub async fn get_latest_orientation() -> Option<Orientation> {
-    *LATEST_ORIENTATION.lock().await
-}
-
-/// Return the latest DMP-calibrated gyroscope reading (deg/s).
-pub async fn get_latest_calibrated_gyro() -> Option<Vector3<f32>> {
-    *LATEST_CALIBRATED_GYRO.lock().await
-}
-
-/// Return the latest host-corrected magnetometer reading (µT).
-pub async fn get_latest_calibrated_mag() -> Option<Vector3<f32>> {
-    *LATEST_CALIBRATED_MAG.lock().await
-}
-
-/// Return the latest raw accelerometer reading (g, before DMP correction).
-pub async fn get_latest_raw_accel() -> Option<Vector3<f32>> {
-    *LATEST_RAW_ACCEL.lock().await
-}
-
-/// Return the latest raw gyroscope reading (deg/s, before DMP correction).
-pub async fn get_latest_raw_gyro() -> Option<Vector3<f32>> {
-    *LATEST_RAW_GYRO.lock().await
-}
-
-/// Return the latest raw magnetometer reading (µT, before any correction).
-pub async fn get_latest_raw_mag() -> Option<Vector3<f32>> {
-    *LATEST_RAW_MAG.lock().await
+/// Return a snapshot of all latest IMU readings from a single lock.
+pub async fn get_latest_readings() -> ImuReadings {
+    let r = LATEST_READINGS.lock().await;
+    ImuReadings {
+        orientation: r.orientation,
+        calibrated_gyro: r.calibrated_gyro,
+        calibrated_mag: r.calibrated_mag,
+        raw_accel: r.raw_accel,
+        raw_gyro: r.raw_gyro,
+        raw_mag: r.raw_mag,
+    }
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
@@ -348,36 +342,35 @@ fn interpolate_interference(
     }
 }
 
-/// Update all `LATEST_*` statics and drive-task sensor channels from a DMP packet.
+/// Update the shared `LATEST_READINGS` and drive-task sensor channels from a DMP packet.
 async fn update_statics_from_dmp(packet: &icm20948::dmp::DmpData, calibration: Option<&flash_storage::ImuCalibration>) {
+    let mut readings = LATEST_READINGS.lock().await;
+
     // Raw accelerometer -------------------------------------------------------
     if let Some((ax, ay, az)) = packet.raw_accel {
-        let v = Vector3::new(
+        readings.raw_accel = Some(Vector3::new(
             f32::from(ax) * ACCEL_SCALE_G,
             f32::from(ay) * ACCEL_SCALE_G,
             f32::from(az) * ACCEL_SCALE_G,
-        );
-        *LATEST_RAW_ACCEL.lock().await = Some(v);
+        ));
     }
 
     // Raw gyroscope -----------------------------------------------------------
     if let Some((gx, gy, gz)) = packet.raw_gyro {
-        let v = Vector3::new(
+        readings.raw_gyro = Some(Vector3::new(
             f32::from(gx) * GYRO_SCALE_DPS,
             f32::from(gy) * GYRO_SCALE_DPS,
             f32::from(gz) * GYRO_SCALE_DPS,
-        );
-        *LATEST_RAW_GYRO.lock().await = Some(v);
+        ));
     }
 
     // DMP-calibrated gyroscope (bias subtracted by DMP calibration engine) ----
     if let Some((gx, gy, gz)) = packet.calibrated_gyro {
-        let v = Vector3::new(
+        readings.calibrated_gyro = Some(Vector3::new(
             f32::from(gx) * GYRO_SCALE_DPS,
             f32::from(gy) * GYRO_SCALE_DPS,
             f32::from(gz) * GYRO_SCALE_DPS,
-        );
-        *LATEST_CALIBRATED_GYRO.lock().await = Some(v);
+        ));
     }
 
     // Raw magnetometer (Axis9 mode only) --------------------------------------
@@ -387,7 +380,8 @@ async fn update_statics_from_dmp(packet: &icm20948::dmp::DmpData, calibration: O
             f32::from(my) * MAG_SCALE_UT,
             f32::from(mz) * MAG_SCALE_UT,
         );
-        *LATEST_RAW_MAG.lock().await = Some(v);
+        readings.raw_mag = Some(v);
+        drop(readings);
 
         // Forward raw mag to the drive task for the magnetometer calibration procedure.
         drive::send_mag_measurement(v).await;
@@ -401,7 +395,7 @@ async fn update_statics_from_dmp(packet: &icm20948::dmp::DmpData, calibration: O
             mag_cal.y = (v.y - iy - cal.mag_y_bias) * cal.mag_y_scale;
             mag_cal.z = (v.z - iz - cal.mag_z_bias) * cal.mag_z_scale;
         }
-        *LATEST_CALIBRATED_MAG.lock().await = Some(mag_cal);
+        LATEST_READINGS.lock().await.calibrated_mag = Some(mag_cal);
     }
 }
 
@@ -592,7 +586,7 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor) {
                                         let orientation = dmp_quat_to_orientation(quat);
                                         let timestamp_ms = Instant::now().as_millis();
 
-                                        *LATEST_ORIENTATION.lock().await = Some(orientation);
+                                        LATEST_READINGS.lock().await.orientation = Some(orientation);
 
                                         update_statics_from_dmp(&packet, current_calibration.as_ref()).await;
 

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -29,7 +29,8 @@
 //! # Calibration
 //!
 //! Magnetometer hard/soft-iron and motor-interference correction are applied in
-//! software to the raw mag readings exposed via `ImuReadings::calibrated_mag`. The DMP's
+//! software; the corrected result is exposed via `ImuReadings::calibrated_mag`
+//! (raw readings are in `raw_mag`). The DMP's
 //! own internal calibration engines handle gyroscope and accelerometer bias correction
 //! automatically — no host-injected bias values are needed for those axes.
 //!
@@ -570,7 +571,9 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor) {
                                         readings.calibrated_mag = None;
                                     }
                                 } else {
-                                    warn!("DMP mode switch failed — continuing with {:?}", fusion_mode);
+                                    warn!("DMP mode switch failed — restoring previous {:?}", fusion_mode);
+                                    let old_config = build_dmp_config(fusion_mode);
+                                    let _ = apply_dmp_config(sensor, &old_config).await;
                                 }
                                 fifo_failures = 0;
                             }

--- a/src/task/testmode/imu_6axis.rs
+++ b/src/task/testmode/imu_6axis.rs
@@ -14,8 +14,7 @@ use super::{TestCommand, release_testmode, request_start};
 use crate::task::{
     io::display::{DisplayAction, display_update},
     sensors::imu::{
-        DmpFusionMode, Orientation, get_latest_calibrated_gyro, get_latest_orientation, get_latest_raw_accel,
-        get_latest_raw_gyro, set_dmp_fusion_mode, start_imu_readings, stop_imu_readings,
+        DmpFusionMode, Orientation, get_latest_readings, set_dmp_fusion_mode, start_imu_readings, stop_imu_readings,
     },
 };
 
@@ -73,10 +72,11 @@ async fn imu6_test_task() {
                     break;
                 }
 
-                let orientation = get_latest_orientation().await;
-                let gyro = get_latest_calibrated_gyro().await;
-                let raw_accel = get_latest_raw_accel().await;
-                let raw_gyro = get_latest_raw_gyro().await;
+                let r = get_latest_readings().await;
+                let orientation = r.orientation;
+                let gyro = r.calibrated_gyro;
+                let raw_accel = r.raw_accel;
+                let raw_gyro = r.raw_gyro;
 
                 if orientation.is_none() && gyro.is_none() {
                     missing = missing.saturating_add(1);

--- a/src/task/testmode/imu_9axis.rs
+++ b/src/task/testmode/imu_9axis.rs
@@ -15,9 +15,7 @@ use super::{TestCommand, release_testmode, request_start};
 use crate::task::{
     io::display::{DisplayAction, display_update},
     sensors::imu::{
-        DmpFusionMode, Orientation, get_latest_calibrated_gyro, get_latest_calibrated_mag, get_latest_orientation,
-        get_latest_raw_accel, get_latest_raw_gyro, get_latest_raw_mag, set_dmp_fusion_mode, start_imu_readings,
-        stop_imu_readings,
+        DmpFusionMode, Orientation, get_latest_readings, set_dmp_fusion_mode, start_imu_readings, stop_imu_readings,
     },
 };
 
@@ -75,12 +73,13 @@ async fn imu_test_task() {
                     break;
                 }
 
-                let orientation = get_latest_orientation().await;
-                let gyro = get_latest_calibrated_gyro().await;
-                let mag = get_latest_calibrated_mag().await;
-                let raw_accel = get_latest_raw_accel().await;
-                let raw_gyro = get_latest_raw_gyro().await;
-                let raw_mag = get_latest_raw_mag().await;
+                let r = get_latest_readings().await;
+                let orientation = r.orientation;
+                let gyro = r.calibrated_gyro;
+                let mag = r.calibrated_mag;
+                let raw_accel = r.raw_accel;
+                let raw_gyro = r.raw_gyro;
+                let raw_mag = r.raw_mag;
 
                 if orientation.is_none() && gyro.is_none() && mag.is_none() {
                     missing = missing.saturating_add(1);


### PR DESCRIPTION
Replace six separate `LATEST_*` statics and their individual accessors with a
single `LATEST_READINGS` mutex containing a new `ImuReadings` struct. Expose
all fields through a unified `get_latest_readings()` async function, reducing
lock contention and simplifying the public API. Update the two test-mode tasks
to use the consolidated interface.