### PR TITLE
refactor: deepen perception, drive dispatch, and obstacle handling

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -155,7 +155,7 @@ Four domain-specific state modules under `system/state/`, each with its own `Mut
 When multiple state mutexes must be held: Power → Calibration → Perception → Motion. Prevents deadlocks.
 
 **Drive Subsystem**
-The `drive` module tree. Owns the drive task, command queue, interrupt signal, control algorithms (rotation, distance, brake/coast, differential), sensor feedback channels, and calibration procedures. Commands flow through a thin `dispatch` that routes to control modules via `IntentSetup` / `IntentTeardown` descriptors — sensor lifecycle is declared by each module, not hardcoded in the dispatch. Exposes two public entry points: `send_drive_command` and `send_drive_interrupt`.
+The `drive` module tree. Owns the drive task, command queue, interrupt signal, control algorithms (rotation, distance, brake/coast, differential), sensor feedback channels, and calibration procedures. Commands flow through a thin `dispatch` that routes to control modules. Control modules own sensor setup internally; teardown is declared via `IntentTeardown` descriptors and executed by the dispatch on completion or interrupt. Exposes two public entry points: `send_drive_command` and `send_drive_interrupt`.
 
 **Drive Queue**
 A builder (`DriveQueueBuilder`) that accumulates `DriveCommand` steps and submits them for sequential execution. A single `drive_queue_executor` task runs one queue at a time and emits a single queue-level completion.
@@ -163,11 +163,11 @@ A builder (`DriveQueueBuilder`) that accumulates `DriveCommand` steps and submit
 **Intent**
 A state machine that owns a specific motion behaviour — rotation, distance drive, brake/coast settle, or idle. Each intent is an `ActiveIntent` variant carrying its controller state, completion flag, and lifecycle descriptors. Commands that complete instantly (e.g. `Differential`) are not intents; they are fire-and-forget.
 
-**IntentSetup / IntentTeardown**
-Enums declaring what sensor streams an intent needs during setup and teardown. Control modules return these descriptors from `init()` and `teardown()`; the `dispatch` executes them. This keeps the dispatch thin — it knows to start or stop sensors but not which specific sensors each intent requires.
+**IntentTeardown**
+An enum declaring what sensor streams must be stopped when an intent completes or is interrupted. Each `ActiveIntent` variant returns its teardown descriptor via `teardown()`; the `dispatch` executes it. This keeps the dispatch thin — it knows to stop sensors but not which specific sensors each intent required. Sensor setup is owned by each intent's async `init()` function. See [ADR-0004](docs/adr/0004-intent-setup-removal.md).
 
 **Dispatch**
-The `dispatch` module — the thin seam between the drive command queue and the control modules. Routes incoming `DriveCommand` envelopes, handles standby wake-up, and executes `IntentSetup` / `IntentTeardown` descriptors. Owns no per-intent knowledge.
+The `dispatch` module — the thin seam between the drive command queue and the control modules. Routes incoming `DriveCommand` envelopes, handles standby wake-up, and executes `IntentTeardown` descriptors on completion or interrupt. Owns no per-intent knowledge.
 
 **Behavior Handlers**
 Functions under `task/behavior/` that react to specific events. Domain logic lives here — obstacle fusion, sensor forwarding, battery updates. Called by the orchestrator.
@@ -182,10 +182,19 @@ Embassy tasks that interface with hardware sensors (`task/sensors/`): IMU read l
 Hardware abstraction tasks under `task/io/`: display driver, flash storage (calibration persistence), port expander driver. Use channel-based command APIs.
 
 **Perception**
-The deepened state module that owns obstacle detection. Obsolete: direct `PERCEPTION_STATE` field access. Current: 10 accessor functions including lock-free boolean reads and an obstacle distance threshold that auto-detects obstacles from ultrasonic readings.
+The deepened state module that owns obstacle detection. Obsolete: direct `PERCEPTION_STATE` field access. Current: accessor functions for lock-free boolean reads (`is_obstacle_detected`, `is_ir_obstacle_detected`, `is_ultrasonic_obstacle_detected`) and mutex-guarded reading/angle storage (`set_ultrasonic_reading`, a pure data store). Obstacle classification flows through the event bus: sensor tasks raise `Events::ObstacleDetected`, the behavior handler calls `set_ir_obstacle` / `set_ultrasonic_obstacle` to update atomics. See [ADR-0003](docs/adr/0003-perception-event-bus.md).
 
 **Obstacle Threshold**
-The distance cutoff (default 15 cm, matching the ultrasonic sensor task) used to classify ultrasonic readings as obstacles. Reading distance ≤ threshold → obstacle detected. Overridable via `set_obstacle_threshold`.
+The distance cutoff (default 20 cm, matching the ultrasonic sensor task's `ULTRASONIC_OBSTACLE_THRESHOLD_CM`) used by the ultrasonic sensor task to classify readings as obstacles. Reading distance ≤ threshold → `Events::ObstacleDetected` raised on the event bus. The perception module no longer owns threshold-based classification (see [ADR-0003](docs/adr/0003-perception-event-bus.md)).
+
+**ObstacleSource**
+An enum (`Ir` | `Ultrasonic`) carried by `Events::ObstacleDetected` that identifies which sensor triggered the detection. Used by the obstacle behavior handler to route updates to the correct perception atomic.
+
+**InterruptKind**
+An enum (`EmergencyBrake`, `Stop`, `CancelCurrent`) that specifies how the drive subsystem preempts the active intent. See also [`Dispatch`](#dispatch).
+
+**EmergencyBrake**
+An `InterruptKind::EmergencyBrake` interrupt sent to the drive subsystem when a combined obstacle is detected. Causes immediate active motor braking, cancels the active intent (if any), bumps the command epoch, and drains queued commands. Mode-agnostic since [ADR-0005](docs/adr/0005-agnostic-obstacle-handling.md) — dispatched unconditionally on any obstacle detection across all modes.
 
 **Change Detected**
 An enum (`ChangeDetected`) returned by perception setters: `NoChange`, `ChangedToDetected`, `ChangedToCleared`. Lets callers react to obstacle state transitions without re-reading the combined flag.

--- a/docs/adr/0003-perception-event-bus.md
+++ b/docs/adr/0003-perception-event-bus.md
@@ -1,0 +1,19 @@
+# Ultrasonic perception — event-bus-only path and pure data store
+
+The ultrasonic sensor task wrote obstacle state through two parallel paths: directly via `set_ultrasonic_reading` (which updated atomics) and indirectly via `Events::ObstacleDetected` → `handle_obstacle_detected` → `set_ultrasonic_obstacle` (which updated the same atomics). This dual-write path created a race condition and made the `ChangeDetected` return from `set_ultrasonic_obstacle` unreliable. Additionally, `set_ultrasonic_reading` acquired the perception mutex twice, creating a TOCTOU window between threshold read and reading storage.
+
+## Considered options
+
+**Keep the dual-write path and fix TOCTOU separately.** Would have merged the two mutex acquires in `set_ultrasonic_reading` without addressing the race with the event-bus path. **Rejected** — the dual-write race remained, just with a narrower TOCTOU window.
+
+**Remove the event bus path, make `set_ultrasonic_reading` the sole atomic writer.** Would have made ultrasonic asymmetric with IR (which still uses the event bus). **Rejected** — asymmetry is its own friction; both obstacle sensors should use the same communication pattern.
+
+**Event bus only, `set_ultrasonic_reading` becomes pure data store.** The ultrasonic task classifies obstacles locally (as it already does) and raises `Events::ObstacleDetected`. `handle_obstacle_detected` remains the single writer of both `IR_DETECTED` and `ULTRASONIC_DETECTED` atomics. `set_ultrasonic_reading` stores only the reading + angle in the mutex — no atomics, no threshold read. **Chosen** — symmetric with IR, one writer per atomic, TOCTOU vanishes naturally.
+
+## Consequences
+
+- `set_ultrasonic_reading` loses its threshold-aware obstacle classification and atomic updates. It becomes a pure data store with a single lock scope.
+- `set_ultrasonic_obstacle` remains the sole writer of `ULTRASONIC_DETECTED`, called only from the event-bus path.
+- Both IR and ultrasonic obstacle state follow the same flow: sensor task → event bus → behavior handler → perception atomics.
+- The dual-write race is eliminated.
+- The TOCTOU window is eliminated.

--- a/docs/adr/0004-intent-setup-removal.md
+++ b/docs/adr/0004-intent-setup-removal.md
@@ -1,0 +1,21 @@
+# Delete IntentSetup — intent init owns sensor lifecycle
+
+The `IntentSetup` enum declared what sensor streams each intent needed during setup. Control modules returned a descriptor from `init()`; the `dispatch` executed it via `execute_intent_setup`. In practice, only `EncoderSettle` (brake/coast) was used; `RotationImu` was dead (rotation's init started IMU itself) and `DistanceImuAndEncoder` was partially bypassed (dispatch did most setup inline in `handle_drive_distance` before the descriptor was executed).
+
+After making `handle_drive_distance` consistent with other intents and giving `DistanceDriveState` an async `init()`, all three control modules own their full setup internally. `execute_intent_setup` has no real work. The seam had one real adapter and two dead ones — a hypothetical seam, not a real one.
+
+## Considered options
+
+**Make the descriptor system real.** Move sensor start from `init()` into `execute_intent_setup` for all three intents. Dispatch owns sensor lifecycle. **Rejected** — adds indirection without leverage. The dispatch gains no new capability (it can't substitute sensors, can't test them independently), and the one-caller-per-descriptor ratio means the seam is hypothetical. Complexity moves from init functions to a central match statement.
+
+**Delete IntentSetup, keep IntentTeardown.** `IntentTeardown` is real — all three variants are executed by `execute_intent_teardown` on completion or interrupt, and the teardown logic (stop encoder, stop IMU, zero motors) benefits from centralisation since it runs from both the completion and interrupt paths. **Chosen** — setup is init's responsibility; teardown is dispatch's. Teardown remains a real seam with two callers (completion and interrupt).
+
+## Consequences
+
+- `IntentSetup` enum and `execute_intent_setup` are deleted.
+- `IntentTeardown` and `execute_intent_teardown` remain unchanged.
+- `BrakeCoastState::init()` becomes async and calls `start_encoder_sampling()` internally.
+- `DistanceDriveState::init()` becomes async and owns sensor start, IMU stabilise, reference capture, and initial motor command.
+- `RotationState::init()` unchanged — already async, already owns setup.
+- `handle_drive_distance` in dispatch shrinks to a thin router matching `handle_rotate_exact`.
+- The dispatch is now genuinely thin: route commands, execute teardown on completion/interrupt, manage epoch.

--- a/docs/adr/0004-intent-setup-removal.md
+++ b/docs/adr/0004-intent-setup-removal.md
@@ -15,7 +15,7 @@ After making `handle_drive_distance` consistent with other intents and giving `D
 - `IntentSetup` enum and `execute_intent_setup` are deleted.
 - `IntentTeardown` and `execute_intent_teardown` remain unchanged.
 - `BrakeCoastState::init()` becomes async and calls `start_encoder_sampling()` internally.
-- `DistanceDriveState::init()` becomes async and owns sensor start, IMU stabilise, reference capture, and initial motor command.
+- `DistanceDriveState::init()` becomes async and owns sensor start, reference capture, and initial motor command. IMU startup + DMP stabilisation is handled by the dispatch gate (`ensure_imu_ready`).
 - `RotationState::init()` unchanged — already async, already owns setup.
 - `handle_drive_distance` in dispatch shrinks to a thin router matching `handle_rotate_exact`.
 - The dispatch is now genuinely thin: route commands, execute teardown on completion/interrupt, manage epoch.

--- a/docs/adr/0005-agnostic-obstacle-handling.md
+++ b/docs/adr/0005-agnostic-obstacle-handling.md
@@ -1,0 +1,19 @@
+# Mode-agnostic obstacle handling — unconditional EmergencyBrake
+
+The obstacle behavior handler (`handle_obstacle_detected`) directly checked `coast_obstacle_avoid::is_active()`, `coast_obstacle_avoid::is_forward_phase()`, and `attempt_straight_line::is_active()` to decide whether to send an `EmergencyBrake` interrupt. This coupled the handler to knowledge of which autonomous modes existed and what phases they were in. Adding a third autonomous mode would require editing the obstacle handler.
+
+## Considered options
+
+**Mode self-filtering via atomics.** Each autonomous mode task reads perception atomics in its own control loop and self-interrupts. **Rejected** — adds worst-case 20ms latency (control tick period) vs. the current direct `Signal` wake. Obstacle avoidance needs immediate braking.
+
+**Registration mechanism.** Modes register a wake signal with the handler. **Rejected** — one adapter means a hypothetical seam. Adds complexity without a second consumer.
+
+**Unconditional EmergencyBrake.** `handle_obstacle_detected` sends an `EmergencyBrake` interrupt on any combined obstacle detection, regardless of mode. `handle_interrupt` in dispatch brakes motors, bumps the command epoch, and drains queued commands — even when no intent is active. This is the intended safety behaviour: IR sensors are armed in all modes (RC, autonomous, testing), and obstacle braking is a system-wide safety invariant. The epoch bump + queue drain are side-effects that always apply; non-autonomous callers should not queue commands they cannot afford to lose. **Chosen** — simplest change, preserves immediate wake, mode-agnostic handler, zero coupling, consistent safety response across all modes.
+
+## Consequences
+
+- `handle_obstacle_detected` loses all imports of `coast_obstacle_avoid` and `attempt_straight_line`.
+- The handler's logic reduces to: update perception atomics → update LED indicator → send unconditional `EmergencyBrake` if combined obstacle detected.
+- New autonomous modes require no changes to the obstacle handler.
+- IR obstacle sensors are armed in all modes (RC, autonomous, testing). Obstacle braking is a system-wide safety invariant: any obstacle detection immediately brakes motors, bumps the command epoch, and drains queued drive commands.
+- Callers that queue drive commands during RC mode or testing must expect them to be dropped on obstacle detection.

--- a/src/system/state/perception.rs
+++ b/src/system/state/perception.rs
@@ -19,37 +19,26 @@ use crate::system::event::UltrasonicReading;
 
 /// IR obstacle detection flag — updated by `set_ir_obstacle`, read lock-free.
 static IR_DETECTED: AtomicBool = AtomicBool::new(false);
-/// Ultrasonic obstacle detection flag — updated by `set_ultrasonic_obstacle` and
-/// `set_ultrasonic_reading`, read lock-free.
+/// Ultrasonic obstacle detection flag — updated by `set_ultrasonic_obstacle`, read lock-free.
 static ULTRASONIC_DETECTED: AtomicBool = AtomicBool::new(false);
 /// Combined obstacle flag — `IR_DETECTED || ULTRASONIC_DETECTED`.
 /// Recomputed atomically by every mutating accessor, read lock-free.
 static COMBINED_DETECTED: AtomicBool = AtomicBool::new(false);
 
-// ── Mutex (full picture: readings, angle, threshold) ──────────────────────────
+// ── Mutex (full picture: readings, angle) ─────────────────────────────────────
 
-/// Default obstacle distance threshold (cm). Used by `set_ultrasonic_reading` to
-/// auto-detect obstacles from raw distance readings.
-///
-/// Matches the ultrasonic sensor task's `ULTRASONIC_OBSTACLE_THRESHOLD_CM` (20 cm)
-/// so lock-free readers see the same obstacle state the event system produces.
-const DEFAULT_OBSTACLE_THRESHOLD_CM: f64 = 20.0;
-
-/// Mutex-guarded state holding ultrasonic readings and threshold.
+/// Mutex-guarded state holding ultrasonic readings.
 static STATE: Mutex<CriticalSectionRawMutex, PerceptionState> = Mutex::new(PerceptionState {
     ultrasonic_reading: None,
     ultrasonic_angle_deg: None,
-    obstacle_threshold_cm: DEFAULT_OBSTACLE_THRESHOLD_CM,
 });
 
-/// Internal state behind the mutex — readings, angle, and threshold.
+/// Internal state behind the mutex — readings and angle.
 struct PerceptionState {
     /// Latest ultrasonic reading, if available.
     ultrasonic_reading: Option<UltrasonicReading>,
     /// Latest ultrasonic servo angle (degrees), if available.
     ultrasonic_angle_deg: Option<f32>,
-    /// Current obstacle distance threshold (cm).
-    obstacle_threshold_cm: f64,
 }
 
 // ── Change detection ──────────────────────────────────────────────────────────
@@ -105,31 +94,14 @@ pub fn is_ultrasonic_obstacle_detected() -> bool {
 
 // ── Public accessors (async — touch the mutex) ────────────────────────────────
 
-/// Store an ultrasonic reading and angle, auto-applying the current obstacle
-/// threshold to update the ultrasonic obstacle flag.
+/// Store an ultrasonic reading and angle in the mutex.
+///
+/// Obstacle classification and atomic flag updates are handled by the event-bus
+/// path (see [`set_ultrasonic_obstacle`]); this function is a pure data store.
 pub async fn set_ultrasonic_reading(reading: Option<UltrasonicReading>, angle_deg: f32) {
-    let obstacle = match reading {
-        Some(UltrasonicReading::Distance(cm)) => {
-            let threshold = { STATE.lock().await.obstacle_threshold_cm };
-            cm < threshold
-        }
-        _ => false,
-    };
-
-    {
-        let mut state = STATE.lock().await;
-        state.ultrasonic_reading = reading;
-        state.ultrasonic_angle_deg = Some(angle_deg);
-    }
-
-    let old_combined = COMBINED_DETECTED.load(Ordering::Relaxed);
-    ULTRASONIC_DETECTED.store(obstacle, Ordering::Relaxed);
-    recompute_combined();
-    let _new_combined = COMBINED_DETECTED.load(Ordering::Relaxed);
-    // Note: no ChangeDetected return here — the ultrasonic task's own
-    // ObstacleDetected event handles reaction. This path just keeps the
-    // atomic mirrors correct for lock-free readers.
-    let _ = old_combined;
+    let mut state = STATE.lock().await;
+    state.ultrasonic_reading = reading;
+    state.ultrasonic_angle_deg = Some(angle_deg);
 }
 
 /// Clear ultrasonic reading, angle, and obstacle flag (e.g. when exiting a test mode).
@@ -142,7 +114,7 @@ pub async fn clear_ultrasonic_data() {
     state.ultrasonic_angle_deg = None;
 }
 
-/// Reset all obstacle flags, ultrasonic data, and threshold to defaults.
+/// Reset all obstacle flags and ultrasonic data to defaults.
 pub async fn reset_all() {
     IR_DETECTED.store(false, Ordering::Relaxed);
     ULTRASONIC_DETECTED.store(false, Ordering::Relaxed);
@@ -151,7 +123,6 @@ pub async fn reset_all() {
     let mut state = STATE.lock().await;
     state.ultrasonic_reading = None;
     state.ultrasonic_angle_deg = None;
-    state.obstacle_threshold_cm = DEFAULT_OBSTACLE_THRESHOLD_CM;
 }
 
 /// Return the latest ultrasonic reading and servo angle from a single lock
@@ -159,14 +130,6 @@ pub async fn reset_all() {
 pub async fn ultrasonic_sweep_snapshot() -> (Option<UltrasonicReading>, Option<f32>) {
     let state = STATE.lock().await;
     (state.ultrasonic_reading, state.ultrasonic_angle_deg)
-}
-
-/// Override the obstacle detection distance threshold (cm).
-/// Distance readings < this value are considered obstacles by `set_ultrasonic_reading`.
-#[allow(dead_code)]
-pub async fn set_obstacle_threshold(cm: f64) {
-    let mut state = STATE.lock().await;
-    state.obstacle_threshold_cm = cm;
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────

--- a/src/task/autonomous_mode/attempt_straight_line.rs
+++ b/src/task/autonomous_mode/attempt_straight_line.rs
@@ -124,9 +124,9 @@ pub(super) fn spawn(spawner: Spawner, target_distance_cm: u16) {
 }
 
 /// Request a graceful stop of the mode.
-pub fn stop() {
+pub async fn stop() {
     ACTIVE.store(false, Ordering::Relaxed);
-    stop_ultrasonic_measurements();
+    stop_ultrasonic_measurements().await;
     send_drive_interrupt(InterruptKind::EmergencyBrake);
 }
 
@@ -207,7 +207,7 @@ pub async fn attempt_straight_line_task(target_distance_cm: u16) {
                 }
                 info!("attempt-straight: sweeping");
                 SWEEP_COMPLETED.reset();
-                ultrasonic::start_buffered_sweep();
+                ultrasonic::start_buffered_sweep().await;
 
                 // Wait for sweep completion, polling ACTIVE so we can abort cleanly.
                 loop {
@@ -303,7 +303,7 @@ pub async fn attempt_straight_line_task(target_distance_cm: u16) {
 
                 // Set ultrasonic to center with obstacle detection for emergency
                 // braking during the forward drive phase.
-                start_ultrasonic_centered_obstacle_detect();
+                start_ultrasonic_centered_obstacle_detect().await;
 
                 let completion = match queue.submit().await {
                     Ok(completion) => completion,

--- a/src/task/autonomous_mode/attempt_straight_line.rs
+++ b/src/task/autonomous_mode/attempt_straight_line.rs
@@ -123,12 +123,6 @@ pub(super) fn spawn(spawner: Spawner, target_distance_cm: u16) {
     spawner.spawn(attempt_straight_line_task(target_distance_cm).unwrap());
 }
 
-/// Returns `true` while the mode is running.
-#[allow(dead_code)]
-pub fn is_active() -> bool {
-    ACTIVE.load(Ordering::Relaxed)
-}
-
 /// Request a graceful stop of the mode.
 pub fn stop() {
     ACTIVE.store(false, Ordering::Relaxed);

--- a/src/task/autonomous_mode/coast_obstacle_avoid.rs
+++ b/src/task/autonomous_mode/coast_obstacle_avoid.rs
@@ -28,9 +28,6 @@
 //! Call [`start`] to begin the mode and [`stop`] to request a graceful exit.
 //! [`stop`] also sends an `EmergencyBrake` interrupt to unblock any active drive
 //! command immediately.
-//!
-//! [`is_active`] can be polled by other parts of the system (e.g. the obstacle
-//! behavior handler) to decide whether to issue drive interrupts.
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
@@ -59,13 +56,8 @@ use crate::{
 // ── Active flag ───────────────────────────────────────────────────────────────
 
 /// Set while the coast-and-avoid loop is running.
-///
-/// Checked by the obstacle behavior handler to decide whether to issue drive
-/// interrupts, and by the loop itself to detect stop requests.
+/// Checked by the loop itself to detect stop requests.
 static ACTIVE: AtomicBool = AtomicBool::new(false);
-
-/// Set while the forward-drive phase is active (used to gate obstacle interrupts).
-static FORWARD_PHASE: AtomicBool = AtomicBool::new(false);
 
 // ── Tuning constants ──────────────────────────────────────────────────────────
 
@@ -101,16 +93,6 @@ pub(super) fn spawn(spawner: Spawner) {
     spawner.spawn(coast_obstacle_avoid_task().unwrap());
 }
 
-/// Returns `true` while the coast-and-avoid loop is running.
-pub fn is_active() -> bool {
-    ACTIVE.load(Ordering::Relaxed)
-}
-
-/// Returns `true` while the forward-drive phase is active.
-pub fn is_forward_phase() -> bool {
-    FORWARD_PHASE.load(Ordering::Relaxed)
-}
-
 /// Activate the coast-and-avoid autonomous mode.
 ///
 /// Requests mode start through the autonomous mode controller.
@@ -120,7 +102,6 @@ pub async fn start() -> bool {
     }
 
     ACTIVE.store(true, Ordering::Relaxed);
-    FORWARD_PHASE.store(false, Ordering::Relaxed);
     start_ultrasonic_centered_obstacle_detect();
     true
 }
@@ -132,7 +113,6 @@ pub async fn start() -> bool {
 /// [`DriveDistance`] or [`RotateExact`] command immediately.
 pub fn stop() {
     ACTIVE.store(false, Ordering::Relaxed);
-    FORWARD_PHASE.store(false, Ordering::Relaxed);
     stop_ultrasonic_measurements();
     send_drive_interrupt(InterruptKind::EmergencyBrake);
 }
@@ -174,28 +154,9 @@ pub async fn coast_obstacle_avoid_task() {
     info!("coast-avoid: deactivated");
 }
 
-/// Helper guard to mark the forward-drive phase for obstacle gating.
-struct ForwardPhaseGuard;
-
-impl ForwardPhaseGuard {
-    /// Enter the forward-drive phase.
-    fn new() -> Self {
-        FORWARD_PHASE.store(true, Ordering::Relaxed);
-        Self
-    }
-}
-
-impl Drop for ForwardPhaseGuard {
-    fn drop(&mut self) {
-        FORWARD_PHASE.store(false, Ordering::Relaxed);
-    }
-}
-
 /// Issue a near-infinite `DriveDistance` forward and wait for it to complete
 /// (either cancelled by an interrupt or, extremely unlikely, finished).
 async fn drive_forward() -> CompletionStatus {
-    let _forward_phase = ForwardPhaseGuard::new();
-
     // If an obstacle was already detected before the forward phase started
     // (e.g. IR event fired during startup), skip the drive entirely and
     // signal cancellation immediately so the avoid loop can react.

--- a/src/task/autonomous_mode/coast_obstacle_avoid.rs
+++ b/src/task/autonomous_mode/coast_obstacle_avoid.rs
@@ -102,7 +102,7 @@ pub async fn start() -> bool {
     }
 
     ACTIVE.store(true, Ordering::Relaxed);
-    start_ultrasonic_centered_obstacle_detect();
+    start_ultrasonic_centered_obstacle_detect().await;
     true
 }
 
@@ -111,9 +111,9 @@ pub async fn start() -> bool {
 /// Clears the active flag so the loop exits after the current drive command
 /// resolves, and sends an `EmergencyBrake` interrupt to unblock any in-progress
 /// [`DriveDistance`] or [`RotateExact`] command immediately.
-pub fn stop() {
+pub async fn stop() {
     ACTIVE.store(false, Ordering::Relaxed);
-    stop_ultrasonic_measurements();
+    stop_ultrasonic_measurements().await;
     send_drive_interrupt(InterruptKind::EmergencyBrake);
 }
 

--- a/src/task/behavior/obstacle.rs
+++ b/src/task/behavior/obstacle.rs
@@ -5,7 +5,6 @@ use defmt::info;
 use crate::{
     system::{event::ObstacleSource, state::perception},
     task::{
-        autonomous_mode::{attempt_straight_line, coast_obstacle_avoid},
         drive::{InterruptKind, send_drive_interrupt},
         indicators::rgb_led_indicate::update_obstacle_indicator,
     },
@@ -19,10 +18,10 @@ pub async fn reset_obstacle_state() {
 
 /// Handle obstacle detection status changes.
 ///
-/// When an obstacle is detected while coast-and-avoid autonomous mode is active,
-/// an `EmergencyBrake` interrupt is sent to the drive task so that the active
-/// `DriveDistance` command resolves immediately as `Cancelled`.  The
-/// coast-and-avoid loop will then run its avoidance maneuver and resume.
+/// Updates perception atomics and unconditionally sends an `EmergencyBrake`
+/// interrupt to the drive task. This is a system-wide safety invariant — IR
+/// sensors are armed in all modes (RC, autonomous, testing). The interrupt
+/// brakes motors, bumps the command epoch, and drains queued commands
 pub fn handle_obstacle_detected(source: ObstacleSource, detected: bool) {
     info!(
         "Obstacle detection status changed: source={:?} detected={}",
@@ -39,22 +38,10 @@ pub fn handle_obstacle_detected(source: ObstacleSource, detected: bool) {
     }
 
     let combined = perception::is_obstacle_detected();
-    if combined && coast_obstacle_avoid::is_active() && coast_obstacle_avoid::is_forward_phase() {
-        info!("coast-avoid forward phase — issuing EmergencyBrake");
-        send_drive_interrupt(InterruptKind::EmergencyBrake);
-    } else if combined && attempt_straight_line::is_active() {
-        // During the DRIVING phase of attempt-straight-line, ultrasonic obstacle
-        // detection is armed (via start_ultrasonic_centered_obstacle_detect).
-        // IR events may also fire.  In both cases, an EmergencyBrake interrupt
-        // cancels the active DriveDistance leg so the robot stops and re-sweeps.
-        info!("attempt-straight drive phase — issuing EmergencyBrake");
+    update_obstacle_indicator(combined);
+    if combined {
         send_drive_interrupt(InterruptKind::EmergencyBrake);
     }
-
-    // Always update the indicator — for Ultrasonic the atomics may already
-    // have been set by set_ultrasonic_reading(), causing set_ultrasonic_obstacle()
-    // to return NoChange even though the obstacle state genuinely changed.
-    update_obstacle_indicator(combined);
 }
 
 /// Handle obstacle avoidance completion.

--- a/src/task/drive/brake_coast.rs
+++ b/src/task/drive/brake_coast.rs
@@ -20,9 +20,10 @@
 
 use embassy_time::{Duration, Instant};
 
-use crate::task::{drive::sensors::data::get_latest_encoder_measurement, sensors::encoders::EncoderMeasurement};
-
-use crate::task::drive::sensors::control as lifecycle;
+use crate::task::{
+    drive::sensors::{control as lifecycle, data::get_latest_encoder_measurement},
+    sensors::encoders::EncoderMeasurement,
+};
 
 /// Encoder settle interval for brake/coast completion (milliseconds).
 pub(super) const SETTLE_INTERVAL_MS: u64 = 100;

--- a/src/task/drive/brake_coast.rs
+++ b/src/task/drive/brake_coast.rs
@@ -6,8 +6,8 @@
 //!
 //! # Lifecycle
 //!
-//! - `init()` creates the settle state and declares an `IntentSetup::EncoderSettle`
-//!   descriptor. The dispatch executes the descriptor to start encoder sampling.
+//! - `init()` creates the settle state, starts encoder sampling, and returns
+//!   an `ActiveIntent`. The dispatch stores the intent directly.
 //! - `run_brake_coast_step()` checks for settle or timeout each tick.
 //! - Completion teardown uses an `IntentTeardown::EncoderSettle` descriptor to
 //!   stop encoder sampling.
@@ -21,6 +21,8 @@
 use embassy_time::{Duration, Instant};
 
 use crate::task::{drive::sensors::data::get_latest_encoder_measurement, sensors::encoders::EncoderMeasurement};
+
+use crate::task::drive::sensors::control as lifecycle;
 
 /// Encoder settle interval for brake/coast completion (milliseconds).
 pub(super) const SETTLE_INTERVAL_MS: u64 = 100;
@@ -45,15 +47,15 @@ pub(super) struct BrakeCoastState {
 impl BrakeCoastState {
     /// Initialise a brake/coast settle intent.
     ///
-    /// Returns the `ActiveIntent` + `IntentSetup::EncoderSettle` descriptor
-    /// (the dispatch executes the descriptor to start encoder sampling).
-    pub(super) fn init(completion_requested: bool) -> (super::state::ActiveIntent, super::types::IntentSetup) {
+    /// Starts encoder sampling and returns the `ActiveIntent`.
+    pub(super) async fn init(completion_requested: bool) -> super::state::ActiveIntent {
+        lifecycle::start_encoder_sampling(SETTLE_INTERVAL_MS, true).await;
+
         let state = Self::new();
-        let intent = super::state::ActiveIntent::BrakeCoast {
+        super::state::ActiveIntent::BrakeCoast {
             state,
             completion_requested,
-        };
-        (intent, super::types::IntentSetup::EncoderSettle)
+        }
     }
 
     /// Create a new settle state with timeout applied.

--- a/src/task/drive/dispatch.rs
+++ b/src/task/drive/dispatch.rs
@@ -383,6 +383,7 @@ async fn ensure_imu_ready() -> bool {
     }
 
     if !got_sample {
+        lifecycle::stop_rotation_imu();
         return false;
     }
 

--- a/src/task/drive/dispatch.rs
+++ b/src/task/drive/dispatch.rs
@@ -353,21 +353,17 @@ const fn action_requires_imu(action: &DriveAction) -> bool {
 
 /// Ensure the IMU is streaming stabilised data.
 ///
-/// On first call: starts the IMU with default fusion mode, waits for the first
-/// DMP FIFO sample (1 s timeout), waits 150 ms for DMP filter stabilisation,
-/// drains stale samples. Returns `true` if the IMU is ready; `false` on timeout.
-/// Subsequent calls return `true` immediately.
+/// On first call (and after every IMU stop): starts the IMU with default fusion
+/// mode, waits for the first DMP FIFO sample (1 s timeout), waits 150 ms for DMP
+/// filter stabilisation, drains stale samples. Returns `true` if the IMU is ready;
+/// `false` on timeout. If the IMU is already streaming, returns `true` immediately.
 async fn ensure_imu_ready() -> bool {
-    use core::sync::atomic::Ordering;
-
     use embassy_time::{Duration, Instant, Timer};
 
     const IMU_STABILISE_MS: u64 = 150;
     const IMU_WAIT_TIMEOUT_MS: u64 = 1000;
 
-    static IMU_STABILISED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
-
-    if IMU_STABILISED.load(Ordering::Relaxed) {
+    if crate::task::sensors::imu::IMU_READY.load(core::sync::atomic::Ordering::Relaxed) {
         return true;
     }
 
@@ -396,6 +392,5 @@ async fn ensure_imu_ready() -> bool {
     // Drain any stale samples accumulated during stabilise.
     while IMU_FEEDBACK_CHANNEL.receiver().try_receive().is_ok() {}
 
-    IMU_STABILISED.store(true, Ordering::Relaxed);
     true
 }

--- a/src/task/drive/dispatch.rs
+++ b/src/task/drive/dispatch.rs
@@ -1,25 +1,24 @@
-//! Drive command dispatch — envelope routing, standby wake-up, and IntentSetup/IntentTeardown execution.
+//! Drive command dispatch — envelope routing, standby wake-up, and `IntentTeardown` execution.
 //!
 //! This module is the thin seam between the drive queue and the control modules.
-//! It does NOT own per-intent knowledge — control modules declare their sensor
-//! needs via [`IntentSetup`] and [`IntentTeardown`] descriptors.
+//! It does NOT own per-intent knowledge — control modules declare their
+//! teardown needs via [`IntentTeardown`] descriptors.
 
 use defmt::info;
 use embassy_time::{Duration, Instant, Timer};
-use libm::roundf;
 
 use crate::{
-    system::state::{calibration, motion},
+    system::state::motion,
     task::{
         drive::{
             api::{self, DriveCommandEnvelope},
-            brake_coast::{self, BrakeCoastState},
+            brake_coast::BrakeCoastState,
             differential,
-            distance::{self, DistanceDriveState},
+            distance::DistanceDriveState,
             rotation::RotationState,
             sensors::{control as lifecycle, data::IMU_FEEDBACK_CHANNEL},
             state::{ActiveIntent, DriveLoop},
-            types::{self, CompletionStatus, DriveAction, DriveCommand, DriveCompletion, IntentSetup, IntentTeardown},
+            types::{self, CompletionStatus, DriveAction, DriveCommand, DriveCompletion, IntentTeardown},
         },
         motor_driver::{self, MotorCommand},
     },
@@ -77,6 +76,22 @@ impl DriveLoop {
 
     /// Dispatch a [`DriveAction`] to the appropriate handler.
     pub(super) async fn handle_drive_action(&mut self, action: DriveAction, completion_requested: bool) {
+        // Gate movement commands until the IMU is streaming stabilised data.
+        // On first movement command: start IMU, wait for first sample, wait for
+        // DMP filter stabilise (150 ms). Subsequent commands skip this.
+        // Non-movement commands (Coast, Brake, Idle, Standby) pass through.
+        if action_requires_imu(&action) && !ensure_imu_ready().await {
+            api::send_completion(
+                completion_requested,
+                DriveCompletion {
+                    status: CompletionStatus::Failed("IMU not responding"),
+                    telemetry: types::CompletionTelemetry::None,
+                },
+            )
+            .await;
+            return;
+        }
+
         // Wake from standby if a movement command arrives.
         self.wake_from_standby(&action).await;
 
@@ -164,12 +179,11 @@ impl DriveLoop {
         motion: types::RotationMotion,
         completion_requested: bool,
     ) {
-        let (intent, _setup) = RotationState::init(degrees, direction, motion, completion_requested).await;
+        let intent = RotationState::init(degrees, direction, motion, completion_requested).await;
         self.active_intent = Some(intent);
     }
 
-    /// Handle a `DriveDistance` command — delegates to `distance::new()`.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    /// Handle a `DriveDistance` command — delegates to `distance::init()`.
     async fn handle_drive_distance(
         &mut self,
         kind: types::DriveDistanceKind,
@@ -177,74 +191,9 @@ impl DriveLoop {
         speed: u8,
         completion_requested: bool,
     ) {
-        /// IMU DMP filter stabilisation delay after enabling (milliseconds).
-        const IMU_STABILISE_MS: u64 = 150;
-        /// Maximum time to wait for the first IMU sample (milliseconds).
-        const IMU_WAIT_TIMEOUT_MS: u64 = 1000;
-
-        let distance_factor = calibration::get_distance_factor().await;
-        let mut state = DistanceDriveState::new(kind, direction, speed, distance_factor);
-
-        // Early exit for trivially short distances.
-        if state.target_inner_revs <= distance::TOLERANCE_REVS {
-            api::send_completion(
-                completion_requested,
-                DriveCompletion {
-                    status: CompletionStatus::Success,
-                    telemetry: types::CompletionTelemetry::DriveDistance {
-                        achieved_left_revs: 0.0,
-                        achieved_right_revs: 0.0,
-                        target_left_revs: state.target_left_revs,
-                        target_right_revs: state.target_right_revs,
-                        duration_ms: 0,
-                    },
-                },
-            )
-            .await;
-            return;
+        if let Some(intent) = DistanceDriveState::init(kind, direction, speed, completion_requested).await {
+            self.active_intent = Some(intent);
         }
-
-        // Start sensors via descriptor.
-        execute_intent_setup(types::IntentSetup::DistanceImuAndEncoder).await;
-
-        // Capture reference yaw from IMU before any movement starts.
-        // The DMP filters need time to stabilise after being enabled — wait for
-        // the first sample to confirm the IMU is alive, then allow 150 ms settle.
-        let deadline = Instant::now() + Duration::from_millis(IMU_WAIT_TIMEOUT_MS);
-        while state.reference_yaw.is_none() && Instant::now() < deadline {
-            while let Ok(m) = IMU_FEEDBACK_CHANNEL.receiver().try_receive() {
-                state.reference_yaw = Some(m.orientation.yaw);
-            }
-            if state.reference_yaw.is_none() {
-                Timer::after(Duration::from_millis(10)).await;
-            }
-        }
-        Timer::after(Duration::from_millis(IMU_STABILISE_MS)).await;
-        // Drain the channel again for a stabilised sample to use as the true reference.
-        while let Ok(m) = IMU_FEEDBACK_CHANNEL.receiver().try_receive() {
-            state.reference_yaw = Some(m.orientation.yaw);
-        }
-
-        // Apply initial speeds.
-        let base_speed = speed.min(distance::MAX_SPEED);
-        let signed_base = match direction {
-            types::DriveDirection::Forward => base_speed as i8,
-            types::DriveDirection::Backward => -(base_speed as i8),
-        };
-        let left_speed = roundf(f32::from(signed_base) * state.left_ratio) as i8;
-        let right_speed = roundf(f32::from(signed_base) * state.right_ratio) as i8;
-
-        motor_driver::send_motor_command(MotorCommand::SetTracks {
-            left_speed,
-            right_speed,
-        })
-        .await;
-        motion::set_track_speeds(left_speed, right_speed).await;
-
-        self.active_intent = Some(ActiveIntent::DriveDistance {
-            state,
-            completion_requested,
-        });
     }
 
     /// Handle a `Coast` command.
@@ -253,8 +202,7 @@ impl DriveLoop {
         motor_driver::send_motor_command(MotorCommand::CoastAll).await;
         motion::set_track_speeds(0, 0).await;
 
-        let (intent, setup) = BrakeCoastState::init(completion_requested);
-        execute_intent_setup(setup).await;
+        let intent = BrakeCoastState::init(completion_requested).await;
         self.active_intent = Some(intent);
     }
 
@@ -264,8 +212,7 @@ impl DriveLoop {
         motor_driver::send_motor_command(MotorCommand::BrakeAll).await;
         motion::set_track_speeds(0, 0).await;
 
-        let (intent, setup) = BrakeCoastState::init(completion_requested);
-        execute_intent_setup(setup).await;
+        let intent = BrakeCoastState::init(completion_requested).await;
         self.active_intent = Some(intent);
     }
 
@@ -369,23 +316,7 @@ impl DriveLoop {
     }
 }
 
-// ── Setup / Teardown execution ─────────────────────────────────────────────
-
-/// Execute the sensor setup declared by a control module's init.
-async fn execute_intent_setup(setup: IntentSetup) {
-    match setup {
-        IntentSetup::RotationImu | IntentSetup::None => {
-            // RotationState::init() already started IMU streaming.
-        }
-        IntentSetup::DistanceImuAndEncoder => {
-            lifecycle::start_distance_imu(&types::DriveDistanceKind::Straight { distance_cm: 0.0 });
-            lifecycle::start_encoder_sampling(distance::CONTROL_INTERVAL_MS, true).await;
-        }
-        IntentSetup::EncoderSettle => {
-            lifecycle::start_encoder_sampling(brake_coast::SETTLE_INTERVAL_MS, true).await;
-        }
-    }
-}
+// ── Teardown execution ─────────────────────────────────────────────────────
 
 /// Execute the sensor teardown declared by a control module.
 pub(super) async fn execute_intent_teardown(teardown: IntentTeardown) {
@@ -410,4 +341,60 @@ pub(super) async fn execute_intent_teardown(teardown: IntentTeardown) {
         }
         IntentTeardown::None => {}
     }
+}
+
+/// Returns `true` if the drive action requires IMU data.
+const fn action_requires_imu(action: &DriveAction) -> bool {
+    matches!(
+        action,
+        DriveAction::Differential { .. } | DriveAction::DriveDistance { .. } | DriveAction::RotateExact { .. }
+    )
+}
+
+/// Ensure the IMU is streaming stabilised data.
+///
+/// On first call: starts the IMU with default fusion mode, waits for the first
+/// DMP FIFO sample (1 s timeout), waits 150 ms for DMP filter stabilisation,
+/// drains stale samples. Returns `true` if the IMU is ready; `false` on timeout.
+/// Subsequent calls return `true` immediately.
+async fn ensure_imu_ready() -> bool {
+    use core::sync::atomic::Ordering;
+    use embassy_time::{Duration, Instant, Timer};
+
+    const IMU_STABILISE_MS: u64 = 150;
+    const IMU_WAIT_TIMEOUT_MS: u64 = 1000;
+
+    static IMU_STABILISED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+
+    if IMU_STABILISED.load(Ordering::Relaxed) {
+        return true;
+    }
+
+    lifecycle::start_distance_imu(&types::DriveDistanceKind::Straight { distance_cm: 0.0 });
+
+    // Wait for the first sample.
+    let deadline = Instant::now() + Duration::from_millis(IMU_WAIT_TIMEOUT_MS);
+    let mut got_sample = false;
+    while Instant::now() < deadline {
+        while IMU_FEEDBACK_CHANNEL.receiver().try_receive().is_ok() {
+            got_sample = true;
+        }
+        if got_sample {
+            break;
+        }
+        Timer::after(Duration::from_millis(10)).await;
+    }
+
+    if !got_sample {
+        return false;
+    }
+
+    // DMP filter stabilisation.
+    Timer::after(Duration::from_millis(IMU_STABILISE_MS)).await;
+
+    // Drain any stale samples accumulated during stabilise.
+    while IMU_FEEDBACK_CHANNEL.receiver().try_receive().is_ok() {}
+
+    IMU_STABILISED.store(true, Ordering::Relaxed);
+    true
 }

--- a/src/task/drive/dispatch.rs
+++ b/src/task/drive/dispatch.rs
@@ -359,6 +359,7 @@ const fn action_requires_imu(action: &DriveAction) -> bool {
 /// Subsequent calls return `true` immediately.
 async fn ensure_imu_ready() -> bool {
     use core::sync::atomic::Ordering;
+
     use embassy_time::{Duration, Instant, Timer};
 
     const IMU_STABILISE_MS: u64 = 150;

--- a/src/task/drive/distance.rs
+++ b/src/task/drive/distance.rs
@@ -53,7 +53,7 @@
 //! Curve debug logs are rate-limited and compiled only when the `telemetry_logs`
 //! feature is enabled; otherwise no formatting/queueing cost is incurred.
 
-use embassy_time::Instant;
+use embassy_time::{Duration, Instant, Timer};
 use libm::roundf;
 use micromath::F32Ext;
 
@@ -302,9 +302,13 @@ impl DistanceDriveState {
     /// Initialise a distance drive intent.
     ///
     /// Gets the calibration distance factor, constructs state, starts sensors,
-    /// captures the IMU reference yaw (with DMP stabilise delay), applies initial
-    /// motor speeds, and returns the `ActiveIntent`. Returns `None` for trivially
-    /// short distances (completion already sent).
+    /// captures a fresh IMU reference yaw, applies initial motor speeds, and
+    /// returns the `ActiveIntent`. Returns `None` for trivially short distances
+    /// (completion already sent).
+    ///
+    /// The dispatch gate (`ensure_imu_ready`) handles IMU startup + DMP
+    /// stabilisation before this is called; this function drains the latest
+    /// sample and waits briefly for one if the channel is empty.
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
     pub(super) async fn init(
         kind: types::DriveDistanceKind,
@@ -341,6 +345,20 @@ impl DistanceDriveState {
         // Capture reference yaw from the already-stabilised IMU.
         while let Ok(m) = IMU_FEEDBACK_CHANNEL.receiver().try_receive() {
             state.reference_yaw = Some(m.orientation.yaw);
+        }
+
+        // If the channel was empty (gate just drained it before us), wait up to
+        // 50 ms for a fresh sample so straight drives don't start without a heading.
+        if state.reference_yaw.is_none() {
+            let deadline = Instant::now() + Duration::from_millis(50);
+            while state.reference_yaw.is_none() && Instant::now() < deadline {
+                while let Ok(m) = IMU_FEEDBACK_CHANNEL.receiver().try_receive() {
+                    state.reference_yaw = Some(m.orientation.yaw);
+                }
+                if state.reference_yaw.is_none() {
+                    Timer::after(Duration::from_millis(10)).await;
+                }
+            }
         }
 
         // Apply initial speeds.

--- a/src/task/drive/distance.rs
+++ b/src/task/drive/distance.rs
@@ -54,13 +54,18 @@
 //! feature is enabled; otherwise no formatting/queueing cost is incurred.
 
 use embassy_time::Instant;
+use libm::roundf;
 use micromath::F32Ext;
 
 use crate::{
-    system::state,
+    system::state::{self, calibration, motion},
     task::{
         drive::{
-            sensors::data::{self as feedback, IMU_FEEDBACK_CHANNEL},
+            api,
+            sensors::{
+                control as lifecycle,
+                data::{self as feedback, IMU_FEEDBACK_CHANNEL},
+            },
             types,
         },
         motor_driver::{self, MotorCommand},
@@ -292,6 +297,72 @@ impl DistanceDriveState {
             last_encoder_measurement: None,
             started_at_ms: now_ms,
         }
+    }
+
+    /// Initialise a distance drive intent.
+    ///
+    /// Gets the calibration distance factor, constructs state, starts sensors,
+    /// captures the IMU reference yaw (with DMP stabilise delay), applies initial
+    /// motor speeds, and returns the `ActiveIntent`. Returns `None` for trivially
+    /// short distances (completion already sent).
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    pub(super) async fn init(
+        kind: types::DriveDistanceKind,
+        direction: types::DriveDirection,
+        speed: u8,
+        completion_requested: bool,
+    ) -> Option<super::state::ActiveIntent> {
+        let distance_factor = calibration::get_distance_factor().await;
+        let mut state = Self::new(kind, direction, speed, distance_factor);
+
+        // Early exit for trivially short distances.
+        if state.target_inner_revs <= TOLERANCE_REVS {
+            api::send_completion(
+                completion_requested,
+                super::types::DriveCompletion {
+                    status: super::types::CompletionStatus::Success,
+                    telemetry: types::CompletionTelemetry::DriveDistance {
+                        achieved_left_revs: 0.0,
+                        achieved_right_revs: 0.0,
+                        target_left_revs: state.target_left_revs,
+                        target_right_revs: state.target_right_revs,
+                        duration_ms: 0,
+                    },
+                },
+            )
+            .await;
+            return None;
+        }
+
+        // Start sensors. IMU is already running + stabilised by the dispatch gate.
+        lifecycle::start_distance_imu(&kind);
+        lifecycle::start_encoder_sampling(CONTROL_INTERVAL_MS, true).await;
+
+        // Capture reference yaw from the already-stabilised IMU.
+        while let Ok(m) = IMU_FEEDBACK_CHANNEL.receiver().try_receive() {
+            state.reference_yaw = Some(m.orientation.yaw);
+        }
+
+        // Apply initial speeds.
+        let base_speed = speed.min(MAX_SPEED);
+        let signed_base = match direction {
+            types::DriveDirection::Forward => base_speed as i8,
+            types::DriveDirection::Backward => -(base_speed as i8),
+        };
+        let left_speed = roundf(f32::from(signed_base) * state.left_ratio) as i8;
+        let right_speed = roundf(f32::from(signed_base) * state.right_ratio) as i8;
+
+        motor_driver::send_motor_command(MotorCommand::SetTracks {
+            left_speed,
+            right_speed,
+        })
+        .await;
+        motion::set_track_speeds(left_speed, right_speed).await;
+
+        Some(super::state::ActiveIntent::DriveDistance {
+            state,
+            completion_requested,
+        })
     }
 }
 

--- a/src/task/drive/mod.rs
+++ b/src/task/drive/mod.rs
@@ -8,21 +8,17 @@
 //!
 //! The drive subsystem is structured around **intents** — state machines that own
 //! a specific motion behaviour (rotation, distance, brake/coast, idle). The
-//! [`dispatch`] module routes incoming commands to the correct control module via
-//! [`types::IntentSetup`] / [`types::IntentTeardown`] descriptors, keeping the
-//! dispatch thin and per-intent knowledge local.
+//! [`dispatch`] module routes incoming commands to the correct control module.
+//! Control modules own sensor setup internally via async `init()` functions;
+//! teardown is declared via [`types::IntentTeardown`] descriptors.
 //!
 //! ```text
 //! caller ──► DriveCommand ──► dispatch ──► control module init()
 //!                                │              │
-//!                                │         returns (ActiveIntent, IntentSetup)
+//!                                │         returns ActiveIntent
 //!                                │              │
-//!                                │    ┌─────────┘
-//!                                │    ▼
-//!                          execute IntentSetup (start sensors)
-//!                                │
-//!                                ▼
-//!                          intent loop ──► control module run_step()
+//!                                ▼              │
+//!                          intent loop ◄────────┘
 //!                                │
 //!                                ▼
 //!                          execute IntentTeardown (stop sensors)

--- a/src/task/drive/rotation.rs
+++ b/src/task/drive/rotation.rs
@@ -123,14 +123,14 @@ pub struct RotationState {
 impl RotationState {
     /// Initialise a rotation intent — clear IMU samples, zero motors, create state.
     ///
-    /// Returns the `ActiveIntent` and `IntentSetup` descriptor. Motor speeds stay at
-    /// zero until the first IMU sample arrives in the control step.
+    /// Returns the `ActiveIntent`. Motor speeds stay at zero until the first IMU
+    /// sample arrives in the control step.
     pub(super) async fn init(
         degrees: f32,
         direction: types::RotationDirection,
         motion: types::RotationMotion,
         completion_requested: bool,
-    ) -> (super::state::ActiveIntent, types::IntentSetup) {
+    ) -> super::state::ActiveIntent {
         lifecycle::start_rotation_imu();
         clear_imu_measurements();
 
@@ -144,13 +144,11 @@ impl RotationState {
         let state = Self::new(degrees, direction, motion);
         let started_at_ms = embassy_time::Instant::now().as_millis();
 
-        let intent = super::state::ActiveIntent::RotateExact {
+        super::state::ActiveIntent::RotateExact {
             state,
             completion_requested,
             started_at_ms,
-        };
-
-        (intent, types::IntentSetup::RotationImu)
+        }
     }
 
     /// Creates new rotation tracking state.

--- a/src/task/drive/state.rs
+++ b/src/task/drive/state.rs
@@ -7,10 +7,11 @@
 //! # Intent lifecycle
 //!
 //! An intent is a state machine for one motion behaviour. It is created by a
-//! control module's `init()`, polled by the intent loop via the module's
-//! `run_step()`, and torn down via its [`teardown()`](ActiveIntent::teardown)
-//! descriptor. The dispatch owns setup (starting sensors) and teardown (stopping
-//! sensors); the control modules own the runtime logic.
+//! control module's async `init()`, which owns sensor setup, polled by the intent
+//! loop via the module's `run_step()`, and torn down via its
+//! [`teardown()`](ActiveIntent::teardown) descriptor. The dispatch owns teardown
+//! (stopping sensors on completion or interrupt); the control modules own the
+//! runtime logic.
 //!
 //! Each intent carries:
 //! - A controller state (`RotationState`, `DistanceDriveState`, etc.)
@@ -122,7 +123,10 @@ impl ActiveIntent {
             Self::RotateExact {
                 state, started_at_ms, ..
             } => {
-                let last_yaw_deg = state.last_yaw.unwrap_or(0.0);
+                let last_yaw_deg = state.last_yaw.unwrap_or_else(|| {
+                    defmt::warn!("rotation cancelled before first IMU sample — telemetry yaw is 0");
+                    0.0
+                });
                 let duration_ms = Instant::now().as_millis() - started_at_ms;
                 super::types::CompletionTelemetry::RotateExact {
                     final_yaw_deg: last_yaw_deg,

--- a/src/task/drive/types.rs
+++ b/src/task/drive/types.rs
@@ -5,8 +5,8 @@
 //! parameters (rotation tuning, distance tuning, drift tuning, etc.) live in
 //! their respective control modules.
 //!
-//! Also defines the [`IntentSetup`] and [`IntentTeardown`] descriptor enums
-//! that form the seam between the [`super::dispatch`] and the control modules.
+//! Also defines the [`IntentTeardown`] descriptor enum that forms the
+//! seam between the [`super::dispatch`] and the control modules.
 
 // ── Geometry constants (shared across modules) ────────────────────────────
 
@@ -241,7 +241,7 @@ pub enum RotationDirection {
 
 /// Combined motion options during rotation
 #[allow(dead_code)] // for completeness and future use in combined motion commands
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, defmt::Format)]
 pub enum RotationMotion {
     /// Rotate in place at the given rotation speed (0-100)
     ///
@@ -258,22 +258,7 @@ pub enum RotationMotion {
     WhileMoving(i8),
 }
 
-// ── Sensor setup/teardown descriptors ─────────────────────────────────────
-
-/// Sensor setup required when starting an intent.
-/// Declared by the control module, executed by the dispatch.
-#[derive(Debug, Clone, Copy)]
-pub(super) enum IntentSetup {
-    /// Start IMU streaming for rotation.
-    RotationImu,
-    /// Start IMU + encoder for distance drives.
-    DistanceImuAndEncoder,
-    /// Start encoder sampling for brake/coast settle.
-    EncoderSettle,
-    /// No sensor setup needed.
-    #[allow(dead_code)]
-    None,
-}
+// ── Sensor teardown descriptors ───────────────────────────────────────────
 
 /// Sensor teardown required when an intent completes or is cancelled.
 /// Declared by the control module, executed by the dispatch.

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -87,6 +87,11 @@ const DMP_SAMPLE_RATE_HZ: u16 = 100;
 /// drained promptly; `10 ms` (100 Hz) matches `DMP_SAMPLE_RATE_HZ`.
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
+/// Set to `true` after the first successful DMP FIFO sample, indicating the IMU
+/// is streaming orientation data. Checked by the drive dispatch to gate movement
+/// commands until the IMU is ready.
+pub static IMU_READY: AtomicBool = AtomicBool::new(false);
+
 /// Initial delay after power-up before starting IMU initialisation.
 const IMU_BOOT_DELAY_MS: u64 = 200;
 
@@ -648,6 +653,8 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor) {
                                         // 100 Hz sample when the channel is full is lossy but harmless —
                                         // the next sample arrives in 10 ms.
                                         let _ = drive::try_send_imu_measurement(measurement);
+
+                                        IMU_READY.store(true, Ordering::Relaxed);
                                     } else {
                                         // Packet present but no quaternion yet (DMP warming up).
                                         update_statics_from_dmp(&packet, None, current_calibration.as_ref()).await;

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -87,9 +87,9 @@ const DMP_SAMPLE_RATE_HZ: u16 = 100;
 /// drained promptly; `10 ms` (100 Hz) matches `DMP_SAMPLE_RATE_HZ`.
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
-/// Set to `true` after the first successful DMP FIFO sample, indicating the IMU
-/// is streaming orientation data. Checked by the drive dispatch to gate movement
-/// commands until the IMU is ready.
+/// Set to `true` after the first successful DMP FIFO sample, cleared when the
+/// IMU is stopped. The drive dispatch uses this to gate movement commands and
+/// trigger DMP filter stabilisation on each fresh start.
 pub static IMU_READY: AtomicBool = AtomicBool::new(false);
 
 /// Initial delay after power-up before starting IMU initialisation.
@@ -225,6 +225,7 @@ pub fn start_imu_readings() {
 
 /// Signal the IMU task to stop measurements and enter standby.
 pub fn stop_imu_readings() {
+    IMU_READY.store(false, Ordering::Relaxed);
     IMU_CONTROL.signal(ImuCommand::Stop);
 }
 

--- a/src/task/sensors/imu.rs
+++ b/src/task/sensors/imu.rs
@@ -225,7 +225,6 @@ pub fn start_imu_readings() {
 
 /// Signal the IMU task to stop measurements and enter standby.
 pub fn stop_imu_readings() {
-    IMU_READY.store(false, Ordering::Relaxed);
     IMU_CONTROL.signal(ImuCommand::Stop);
 }
 
@@ -564,6 +563,7 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor) {
                         Either::First(ImuCommand::Stop) => {
                             info!("IMU stopped");
                             let _ = sensor.dmp_enable(false).await;
+                            IMU_READY.store(false, Ordering::Relaxed);
                             continue 'command;
                         }
 
@@ -687,6 +687,7 @@ async fn run_imu_command_loop(sensor: &mut ImuSensor) {
             // ── Standby: commands received before Start ────────────────────────
             ImuCommand::Stop => {
                 info!("IMU stop received (already in standby)");
+                IMU_READY.store(false, Ordering::Relaxed);
             }
             ImuCommand::LoadCalibration(cal) => {
                 current_calibration = Some(cal);

--- a/src/task/sensors/ultrasonic.rs
+++ b/src/task/sensors/ultrasonic.rs
@@ -14,7 +14,7 @@ use embassy_rp::{
     pio::Instance,
     pio_programs::pwm::PioPwm,
 };
-use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex, signal::Signal};
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Channel, mutex::Mutex};
 use embassy_time::{Delay, Instant, Timer, with_timeout};
 use hcsr04_async::{Config, DistanceUnit, Hcsr04, Now, TemperatureUnit};
 use heapless::Vec as HeaplessVec;
@@ -46,8 +46,9 @@ enum UltrasonicSweepCommand {
     StartBufferedSweep,
 }
 
-/// Control signal to trigger encoder measurements after specified duration
-static US_SWEEP_CONTROL: Signal<CriticalSectionRawMutex, UltrasonicSweepCommand> = Signal::new();
+/// Control channel for ultrasonic sweep commands (capacity 4 — enough for
+/// a `Stop` → `StartFixed` sequence without losing commands).
+static US_SWEEP_CONTROL: Channel<CriticalSectionRawMutex, UltrasonicSweepCommand, 4> = Channel::new();
 
 /// Sweep buffer for gap analysis: distance in mm per servo angle (0–160°).
 /// None means timeout or error at that angle.
@@ -67,12 +68,12 @@ pub type SweepPoints = HeaplessVec<ObstaclePoint, 32>;
 
 /// Start continuous ultrasonic sweep readings
 pub fn start_ultrasonic_sweep() {
-    US_SWEEP_CONTROL.signal(UltrasonicSweepCommand::StartSweep);
+    let _ = US_SWEEP_CONTROL.try_send(UltrasonicSweepCommand::StartSweep);
 }
 
 /// Start fixed-angle ultrasonic readings (no servo sweep)
 pub fn start_ultrasonic_fixed(angle_deg: f32) {
-    US_SWEEP_CONTROL.signal(UltrasonicSweepCommand::StartFixed {
+    let _ = US_SWEEP_CONTROL.try_send(UltrasonicSweepCommand::StartFixed {
         angle_deg,
         obstacle_detect: false,
     });
@@ -81,7 +82,7 @@ pub fn start_ultrasonic_fixed(angle_deg: f32) {
 /// Start fixed-angle ultrasonic readings with obstacle detection enabled.
 #[allow(dead_code)]
 pub fn start_ultrasonic_fixed_obstacle_detect(angle_deg: f32) {
-    US_SWEEP_CONTROL.signal(UltrasonicSweepCommand::StartFixed {
+    let _ = US_SWEEP_CONTROL.try_send(UltrasonicSweepCommand::StartFixed {
         angle_deg,
         obstacle_detect: true,
     });
@@ -89,7 +90,7 @@ pub fn start_ultrasonic_fixed_obstacle_detect(angle_deg: f32) {
 
 /// Start centered ultrasonic obstacle detection mode.
 pub fn start_ultrasonic_centered_obstacle_detect() {
-    US_SWEEP_CONTROL.signal(UltrasonicSweepCommand::StartFixed {
+    let _ = US_SWEEP_CONTROL.try_send(UltrasonicSweepCommand::StartFixed {
         angle_deg: ULTRASONIC_CENTER_ANGLE_DEG,
         obstacle_detect: true,
     });
@@ -97,13 +98,13 @@ pub fn start_ultrasonic_centered_obstacle_detect() {
 
 /// Stop ultrasonic readings
 pub fn stop_ultrasonic_measurements() {
-    US_SWEEP_CONTROL.signal(UltrasonicSweepCommand::Stop);
+    let _ = US_SWEEP_CONTROL.try_send(UltrasonicSweepCommand::Stop);
 }
 
 /// Start a single buffered 0–160° ultrasonic sweep pass.
 /// After completion, raises `Events::UltrasonicSweepCompleted`.
 pub fn start_buffered_sweep() {
-    US_SWEEP_CONTROL.signal(UltrasonicSweepCommand::StartBufferedSweep);
+    let _ = US_SWEEP_CONTROL.try_send(UltrasonicSweepCommand::StartBufferedSweep);
 }
 
 /// Close an open obstacle run by applying cone correction and resetting tracking state.
@@ -441,7 +442,7 @@ pub async fn ultrasonic_sweep(
     'command: loop {
         info!("Waiting for ultrasonic command");
         // Wait for a command, consuming it
-        match US_SWEEP_CONTROL.wait().await {
+        match US_SWEEP_CONTROL.receive().await {
             UltrasonicSweepCommand::StartSweep => {
                 info!("Starting ultrasonic sweep");
                 teardown_obstacle_detection(&mut obstacle_detection_enabled, &mut last_obstacle_detected).await;
@@ -468,6 +469,10 @@ pub async fn ultrasonic_sweep(
                 }
                 sweeping = false;
                 fixed_angle = angle_deg.clamp(0.0, servo.max_degree_rotation);
+                // Re-center immediately — the inner loop's first rotate_float
+                // is 15 ms away. This guarantees the servo moves even if a
+                // prior Stop command was lost (pre-Channel race condition).
+                servo.rotate_float(fixed_angle);
             }
             UltrasonicSweepCommand::StartBufferedSweep => {
                 info!("Starting buffered ultrasonic sweep");
@@ -495,7 +500,7 @@ pub async fn ultrasonic_sweep(
             servo.rotate_float(measurement_angle);
 
             // Give servo time to reach position, also see if we must stop or switch modes
-            match select(Timer::after_millis(15), US_SWEEP_CONTROL.wait()).await {
+            match select(Timer::after_millis(15), US_SWEEP_CONTROL.receive()).await {
                 Either::First(()) => {}
                 Either::Second(command) => match command {
                     UltrasonicSweepCommand::StartBufferedSweep => {

--- a/src/task/sensors/ultrasonic.rs
+++ b/src/task/sensors/ultrasonic.rs
@@ -67,44 +67,50 @@ pub struct ObstaclePoint {
 pub type SweepPoints = HeaplessVec<ObstaclePoint, 32>;
 
 /// Start continuous ultrasonic sweep readings
-pub fn start_ultrasonic_sweep() {
-    let _ = US_SWEEP_CONTROL.try_send(UltrasonicSweepCommand::StartSweep);
+pub async fn start_ultrasonic_sweep() {
+    US_SWEEP_CONTROL.send(UltrasonicSweepCommand::StartSweep).await;
 }
 
 /// Start fixed-angle ultrasonic readings (no servo sweep)
-pub fn start_ultrasonic_fixed(angle_deg: f32) {
-    let _ = US_SWEEP_CONTROL.try_send(UltrasonicSweepCommand::StartFixed {
-        angle_deg,
-        obstacle_detect: false,
-    });
+pub async fn start_ultrasonic_fixed(angle_deg: f32) {
+    US_SWEEP_CONTROL
+        .send(UltrasonicSweepCommand::StartFixed {
+            angle_deg,
+            obstacle_detect: false,
+        })
+        .await;
 }
 
 /// Start fixed-angle ultrasonic readings with obstacle detection enabled.
 #[allow(dead_code)]
-pub fn start_ultrasonic_fixed_obstacle_detect(angle_deg: f32) {
-    let _ = US_SWEEP_CONTROL.try_send(UltrasonicSweepCommand::StartFixed {
-        angle_deg,
-        obstacle_detect: true,
-    });
+pub async fn start_ultrasonic_fixed_obstacle_detect(angle_deg: f32) {
+    US_SWEEP_CONTROL
+        .send(UltrasonicSweepCommand::StartFixed {
+            angle_deg,
+            obstacle_detect: true,
+        })
+        .await;
 }
 
 /// Start centered ultrasonic obstacle detection mode.
-pub fn start_ultrasonic_centered_obstacle_detect() {
-    let _ = US_SWEEP_CONTROL.try_send(UltrasonicSweepCommand::StartFixed {
-        angle_deg: ULTRASONIC_CENTER_ANGLE_DEG,
-        obstacle_detect: true,
-    });
+pub async fn start_ultrasonic_centered_obstacle_detect() {
+    US_SWEEP_CONTROL
+        .send(UltrasonicSweepCommand::StartFixed {
+            angle_deg: ULTRASONIC_CENTER_ANGLE_DEG,
+            obstacle_detect: true,
+        })
+        .await;
 }
 
 /// Stop ultrasonic readings
-pub fn stop_ultrasonic_measurements() {
-    let _ = US_SWEEP_CONTROL.try_send(UltrasonicSweepCommand::Stop);
+pub async fn stop_ultrasonic_measurements() {
+    US_SWEEP_CONTROL.send(UltrasonicSweepCommand::Stop).await;
 }
 
 /// Start a single buffered 0–160° ultrasonic sweep pass.
 /// After completion, raises `Events::UltrasonicSweepCompleted`.
-pub fn start_buffered_sweep() {
-    let _ = US_SWEEP_CONTROL.try_send(UltrasonicSweepCommand::StartBufferedSweep);
+pub async fn start_buffered_sweep() {
+    US_SWEEP_CONTROL.send(UltrasonicSweepCommand::StartBufferedSweep).await;
 }
 
 /// Close an open obstacle run by applying cone correction and resetting tracking state.

--- a/src/task/sensors/ultrasonic.rs
+++ b/src/task/sensors/ultrasonic.rs
@@ -491,6 +491,7 @@ pub async fn ultrasonic_sweep(
             UltrasonicSweepCommand::Stop => {
                 info!("Stopping ultrasonic measurements");
                 teardown_obstacle_detection(&mut obstacle_detection_enabled, &mut last_obstacle_detected).await;
+                buffered_sweep_active = false;
                 servo.rotate_float(ULTRASONIC_CENTER_ANGLE_DEG);
                 continue 'command;
             }
@@ -526,6 +527,7 @@ pub async fn ultrasonic_sweep(
                         previous_reading = None;
                         info!("Stopping ultrasonic measurements");
                         teardown_obstacle_detection(&mut obstacle_detection_enabled, &mut last_obstacle_detected).await;
+                        buffered_sweep_active = false;
                         servo.rotate_float(ULTRASONIC_CENTER_ANGLE_DEG);
                         continue 'command;
                     }
@@ -560,6 +562,7 @@ pub async fn ultrasonic_sweep(
                             last_obstacle_detected = None;
                         }
                         sweeping = false;
+                        buffered_sweep_active = false;
                         fixed_angle = angle_deg.clamp(0.0, servo.max_degree_rotation);
                     }
                 },

--- a/src/task/testmode/coast_avoid_detection.rs
+++ b/src/task/testmode/coast_avoid_detection.rs
@@ -67,7 +67,7 @@ const TEST_SPEED: u8 = 80;
 #[embassy_executor::task]
 async fn coast_avoid_detection_task() {
     // Mirror coast-avoid sensor setup: centered ultrasonic with obstacle detection.
-    start_ultrasonic_centered_obstacle_detect();
+    start_ultrasonic_centered_obstacle_detect().await;
     display_update(DisplayAction::Clear).await;
 
     // Spin motors at coast-avoid forward speed to reproduce motor PWM noise
@@ -160,7 +160,7 @@ async fn coast_avoid_detection_task() {
         }
     }
 
-    stop_ultrasonic_measurements();
+    stop_ultrasonic_measurements().await;
     motor_driver::send_motor_command(MotorCommand::CoastAll).await;
     motor_driver::send_motor_command(MotorCommand::SetAllDriversEnable { enabled: false }).await;
     crate::system::state::perception::clear_ultrasonic_data().await;

--- a/src/task/testmode/ir_ultrasonic.rs
+++ b/src/task/testmode/ir_ultrasonic.rs
@@ -48,7 +48,7 @@ pub(super) fn spawn(spawner: Spawner) {
 /// IR + ultrasonic test mode runner (updates display at 10Hz while active).
 #[embassy_executor::task]
 async fn ir_ultrasonic_test_task() {
-    start_ultrasonic_fixed(80.0);
+    start_ultrasonic_fixed(80.0).await;
     display_update(DisplayAction::Clear).await;
 
     // Clear any pending stop signal so the next test doesn't end immediately.
@@ -111,7 +111,7 @@ async fn ir_ultrasonic_test_task() {
         }
     }
 
-    stop_ultrasonic_measurements();
+    stop_ultrasonic_measurements().await;
     crate::system::state::perception::clear_ultrasonic_data().await;
     release_testmode();
     IR_ULTRASONIC_TEST_ACTIVE.store(false, Ordering::Relaxed);

--- a/src/task/testmode/ultrasonic_sweep.rs
+++ b/src/task/testmode/ultrasonic_sweep.rs
@@ -53,7 +53,7 @@ pub(super) fn spawn(spawner: Spawner) {
 /// Ultrasonic sweep test mode runner with built-in 10 Hz display loop.
 #[embassy_executor::task]
 async fn ultrasonic_sweep_test_task() {
-    start_ultrasonic_sweep();
+    start_ultrasonic_sweep().await;
     display::display_update(DisplayAction::Clear).await;
 
     // Clear any pending stop signal so the next test doesn't end immediately.
@@ -110,7 +110,7 @@ async fn ultrasonic_sweep_test_task() {
         }
     }
 
-    stop_ultrasonic_measurements();
+    stop_ultrasonic_measurements().await;
     perception::clear_ultrasonic_data().await;
     release_testmode();
     ULTRASONIC_SWEEP_TEST_ACTIVE.store(false, Ordering::Relaxed);

--- a/src/task/ui/mod.rs
+++ b/src/task/ui/mod.rs
@@ -405,10 +405,10 @@ async fn handle_ui_back() {
         UiMode::RunningAutonomous { mode } => {
             match mode {
                 DriveMode::CoastAndAvoid => {
-                    autonomous_mode::coast_obstacle_avoid::stop();
+                    autonomous_mode::coast_obstacle_avoid::stop().await;
                 }
                 DriveMode::AttemptStraightLine => {
-                    attempt_straight_line::stop();
+                    attempt_straight_line::stop().await;
                 }
             }
             show_main_menu().await;


### PR DESCRIPTION
Three architecture decisions implemented (see `docs/adr/0003–0005`):

### ADR-0003 — Perception event-bus-only path
`set_ultrasonic_reading` is now a pure data store (single lock scope, no atomics, no threshold classification). Ultrasonic obstacle state flows through the event bus exclusively, symmetric with IR. The dual-write race on `ULTRASONIC_DETECTED` and TOCTOU window are eliminated.

### ADR-0004 — Delete IntentSetup, init owns setup
`IntentSetup` enum deleted. Each intent's async `init()` owns sensor startup internally. `IntentTeardown` retained (two genuine callers). `handle_drive_distance` in dispatch shrinks to a thin router matching rotation. `DistanceDriveState::init()` is the new async entry point.

### ADR-0005 — Mode-agnostic obstacle handling
`handle_obstacle_detected` sends `EmergencyBrake` unconditionally on any combined obstacle detection — a system-wide safety invariant. IR sensors are armed in all modes. No knowledge of autonomous mode internals. `coast_obstacle_avoid::is_active()`, `is_forward_phase()`, and `attempt_straight_line::is_active()` deleted.

### IMU readiness gate
`ensure_imu_ready()` in dispatch starts the IMU with DMP stabilise (150 ms) on the first movement command. Eliminates the IMU stabilise loop from `DistanceDriveState::init()` and prevents unguided driving when the IMU is not yet streaming.

### Cleanup
- Deleted dead `FORWARD_PHASE` + `ForwardPhaseGuard`
- Deleted dead `obstacle_threshold_cm` + `set_obstacle_threshold()`
- Updated CONTEXT.md glossary entries
- Clippy clean across all profiles and features